### PR TITLE
E2-02 to E2-04: document registry, ingest, and listing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -49,6 +49,9 @@
 | E1-04 | Alembic baseline | codex | ☑ Done | PR TBD |  |
 | E3‑02 | Universal Chunker |  | ☐ To‑Do ☐ Doing ☐ Done |  |  |
 | E2-01 | Object store client | codex | ☑ Done | PR TBD |  |
+| E2-02 | Document registry schema | codex | ☑ Done | PR TBD |  |
+| E2-03 | /ingest endpoint | codex | ☑ Done | PR TBD |  |
+| E2-04 | Document list & filters | codex | ☑ Done | PR TBD |  |
 | E3‑03 | PDF parser v1 |  | ☐ To‑Do ☐ Doing ☐ Done |  |  |
 | E3‑04 | HTML parser v1 |  | ☐ To‑Do ☐ Doing ☐ Done |  |  |
 | E4‑01 | Taxonomy service v1 |  | ☐ To‑Do ☐ Doing ☐ Done |  |  |

--- a/alembic/versions/0001_baseline.py
+++ b/alembic/versions/0001_baseline.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
@@ -10,11 +11,91 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
+        "projects",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "allow_versioning",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
         "documents",
-        sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("name", sa.String, nullable=False),
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Uuid(as_uuid=True),
+            sa.ForeignKey("projects.id"),
+            nullable=False,
+        ),
+        sa.Column("source_type", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("latest_version_id", sa.Uuid(as_uuid=True), nullable=True),
+    )
+
+    op.create_table(
+        "document_versions",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column(
+            "document_id",
+            sa.Uuid(as_uuid=True),
+            sa.ForeignKey("documents.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(as_uuid=True),
+            sa.ForeignKey("projects.id"),
+            nullable=False,
+        ),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("doc_hash", sa.String(length=64), nullable=False),
+        sa.Column("mime", sa.String(), nullable=False),
+        sa.Column("size", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column(
+            "metadata",
+            sa.JSON().with_variant(postgresql.JSONB, "postgresql"),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("document_id", "version", name="uq_document_version"),
+        sa.UniqueConstraint("project_id", "doc_hash", name="uq_project_doc_hash"),
+    )
+
+    op.create_foreign_key(
+        "fk_documents_latest_version_id",
+        "documents",
+        "document_versions",
+        ["latest_version_id"],
+        ["id"],
     )
 
 
 def downgrade() -> None:
+    op.drop_constraint(
+        "fk_documents_latest_version_id", "documents", type_="foreignkey"
+    )
+    op.drop_table("document_versions")
     op.drop_table("documents")
+    op.drop_table("projects")

--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,149 @@
-from fastapi import FastAPI
+import hashlib
+import mimetypes
+import urllib.request
+from typing import Any
+
+import sqlalchemy as sa
+from fastapi import Depends, FastAPI, HTTPException, Request, UploadFile
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from core.settings import get_settings
+from models import Document, DocumentStatus, DocumentVersion, Project
+from storage.object_store import ObjectStore, create_client, raw_key
+from worker.main import parse_document
+
+settings = get_settings()
+engine = sa.create_engine(settings.database_url)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 app = FastAPI()
+
+
+def get_db() -> Any:
+    with SessionLocal() as session:
+        yield session
+
+
+def get_object_store() -> ObjectStore:
+    client = create_client(
+        endpoint=settings.minio_endpoint,
+        access_key=settings.minio_access_key,
+        secret_key=settings.minio_secret_key,
+        secure=settings.minio_secure,
+    )
+    return ObjectStore(client=client, bucket=settings.s3_bucket)
+
+
+@app.post("/ingest")
+async def ingest(
+    request: Request,
+    db: Session = Depends(get_db),
+    store: ObjectStore = Depends(get_object_store),
+) -> dict[str, str]:
+    data: bytes
+    filename: str
+    mime: str
+    project_id: str | None
+
+    if request.headers.get("content-type", "").startswith("multipart/form-data"):
+        form = await request.form()
+        upload = form.get("file")
+        project_field = form.get("project_id")
+        project_id = project_field if isinstance(project_field, str) else None
+        if not isinstance(upload, UploadFile) or project_id is None:
+            raise HTTPException(status_code=400, detail="project_id and file required")
+        data = await upload.read()
+        filename = upload.filename or "upload"
+        mime = (
+            upload.content_type
+            or mimetypes.guess_type(filename)[0]
+            or "application/octet-stream"
+        )
+    else:
+        payload = await request.json()
+        project_id = payload.get("project_id")
+        uri = payload.get("uri")
+        if project_id is None or uri is None:
+            raise HTTPException(status_code=400, detail="project_id and uri required")
+        with urllib.request.urlopen(uri) as resp:  # noqa: S310
+            data = resp.read()
+            mime = resp.headers.get_content_type()
+        filename = uri.split("/")[-1]
+
+    project = db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    doc_hash = hashlib.sha256(data).hexdigest()
+    existing = db.scalar(
+        select(DocumentVersion).where(
+            DocumentVersion.project_id == project_id,
+            DocumentVersion.doc_hash == doc_hash,
+        )
+    )
+    if existing is not None:
+        return {"doc_id": str(existing.document_id)}
+
+    source_type = "html" if "html" in mime else "pdf" if "pdf" in mime else "other"
+    document = Document(project_id=project_id, source_type=source_type)
+    db.add(document)
+    db.flush()
+
+    version = DocumentVersion(
+        document_id=document.id,
+        project_id=project_id,
+        version=1,
+        doc_hash=doc_hash,
+        mime=mime,
+        size=len(data),
+        status=DocumentStatus.INGESTED.value,
+        meta={},
+    )
+    db.add(version)
+    db.flush()
+    document.latest_version_id = version.id
+    db.commit()
+
+    store.put_bytes(raw_key(str(document.id), filename), data)
+    parse_document.delay(str(document.id))
+    return {"doc_id": str(document.id)}
+
+
+@app.get("/documents")
+def list_documents(
+    project_id: str | None = None,
+    type: str | None = None,
+    status: str | None = None,
+    q: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    query = select(Document, DocumentVersion).join(
+        DocumentVersion, DocumentVersion.id == Document.latest_version_id
+    )
+    if project_id:
+        query = query.where(Document.project_id == project_id)
+    if type:
+        query = query.where(Document.source_type == type)
+    if status:
+        query = query.where(DocumentVersion.status == status)
+    if q:
+        query = query.where(sa.cast(DocumentVersion.meta, sa.String).ilike(f"%{q}%"))
+    total = db.scalar(select(sa.func.count()).select_from(query.subquery()))
+    rows = db.execute(query.order_by(Document.id).offset(offset).limit(limit)).all()
+    documents = [
+        {
+            "id": str(doc.id),
+            "project_id": str(doc.project_id),
+            "type": doc.source_type,
+            "status": ver.status,
+            "metadata": ver.meta,
+        }
+        for doc, ver in rows
+    ]
+    return {"documents": documents, "total": total or 0}
 
 
 @app.get("/health")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,5 @@
+from .base import Base
+from .document import Document, DocumentStatus, DocumentVersion
+from .project import Project
+
+__all__ = ["Base", "Project", "Document", "DocumentVersion", "DocumentStatus"]

--- a/models/document.py
+++ b/models/document.py
@@ -1,0 +1,75 @@
+import enum
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class DocumentStatus(str, enum.Enum):
+    INGESTED = "ingested"
+    PARSED = "parsed"
+    NEEDS_REVIEW = "needs_review"
+    FAILED = "failed"
+
+
+json_type = sa.JSON().with_variant(JSONB, "postgresql")
+
+
+class Document(Base):
+    __tablename__ = "documents"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), sa.ForeignKey("projects.id"), nullable=False
+    )
+    source_type: Mapped[str] = mapped_column(sa.String, nullable=False)
+    created_at: Mapped[sa.types.DateTime] = mapped_column(
+        sa.DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), sa.ForeignKey("document_versions.id"), nullable=True
+    )
+
+    project = relationship("Project", back_populates="documents")
+    versions = relationship("DocumentVersion", back_populates="document")
+    latest_version = relationship(
+        "DocumentVersion", foreign_keys=[latest_version_id], uselist=False
+    )
+
+
+class DocumentVersion(Base):
+    __tablename__ = "document_versions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    document_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), sa.ForeignKey("documents.id"), nullable=False
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), sa.ForeignKey("projects.id"), nullable=False
+    )
+    version: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    doc_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    mime: Mapped[str] = mapped_column(sa.String, nullable=False)
+    size: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    status: Mapped[str] = mapped_column(sa.String, nullable=False)
+    meta: Mapped[dict] = mapped_column(
+        "metadata", json_type, default=dict, nullable=False
+    )
+    created_at: Mapped[sa.types.DateTime] = mapped_column(
+        sa.DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    document = relationship("Document", back_populates="versions")
+
+    __table_args__ = (
+        sa.UniqueConstraint("document_id", "version", name="uq_document_version"),
+        sa.UniqueConstraint("project_id", "doc_hash", name="uq_project_doc_hash"),
+    )

--- a/models/project.py
+++ b/models/project.py
@@ -1,0 +1,25 @@
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column(sa.String, nullable=False)
+    allow_versioning: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, default=False
+    )
+    created_at: Mapped[sa.types.DateTime] = mapped_column(
+        sa.DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    documents = relationship("Document", back_populates="project")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "boto3",
     "celery",
     "redis",
-    "python-multipart"
+    "python-multipart",
+    "httpx"
 ]
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ boto3
 celery
 redis
 python-multipart
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+from collections.abc import Generator
+from io import BytesIO
+from typing import List, Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from api.main import app, get_db, get_object_store
+from models import Base, Project
+from storage.object_store import ObjectStore
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    def put_object(self, Bucket: str, Key: str, Body: bytes) -> None:  # noqa: N803
+        self.store[Key] = Body
+
+    def get_object(self, Bucket: str, Key: str) -> dict:  # noqa: N803
+        return {"Body": BytesIO(self.store[Key])}
+
+    def list_objects_v2(self, Bucket: str, Prefix: str) -> dict:  # noqa: N803
+        keys = [k for k in self.store if k.startswith(Prefix)]
+        return {"Contents": [{"Key": k} for k in keys]}
+
+    def generate_presigned_url(
+        self, operation: str, Params: dict, ExpiresIn: int
+    ) -> str:  # noqa: N803
+        return f"https://example.com/{Params['Key']}?X-Amz-Expires={ExpiresIn}"
+
+
+@pytest.fixture
+def test_app() -> (
+    Generator[tuple[TestClient, ObjectStore, List[str], sessionmaker], None, None]
+):
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+
+    with TestingSessionLocal() as session:
+        session.add(Project(id="p1", name="P1", allow_versioning=False))
+        session.add(Project(id="p2", name="P2", allow_versioning=False))
+        session.commit()
+
+    store = ObjectStore(client=FakeS3Client(), bucket="test")
+
+    def override_get_db() -> Generator[Session, None, None]:
+        with TestingSessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_object_store] = lambda: store
+
+    calls: List[str] = []
+
+    from worker import main as worker_main
+
+    def fake_delay(doc_id: str) -> None:
+        calls.append(doc_id)
+
+    worker_main.parse_document.delay = fake_delay
+
+    client = TestClient(app)
+
+    try:
+        yield client, store, calls, TestingSessionLocal
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,61 @@
+from sqlalchemy import select
+
+from models import DocumentStatus, DocumentVersion
+
+
+def test_listing_filters_and_pagination(test_app) -> None:
+    client, _, _, SessionLocal = test_app
+    resp1 = client.post(
+        "/ingest",
+        data={"project_id": "p1"},
+        files={"file": ("a.pdf", b"alpha", "application/pdf")},
+    )
+    doc1 = resp1.json()["doc_id"]
+    resp2 = client.post(
+        "/ingest",
+        data={"project_id": "p1"},
+        files={"file": ("b.html", b"beta", "text/html")},
+    )
+    doc2 = resp2.json()["doc_id"]
+    client.post(
+        "/ingest",
+        data={"project_id": "p2"},
+        files={"file": ("c.pdf", b"gamma", "application/pdf")},
+    )
+
+    with SessionLocal() as db:
+        dv1 = db.scalar(
+            select(DocumentVersion).where(DocumentVersion.document_id == doc1)
+        )
+        assert dv1 is not None
+        dv1.status = DocumentStatus.PARSED.value
+        dv1.meta = {"title": "alpha"}
+        dv2 = db.scalar(
+            select(DocumentVersion).where(DocumentVersion.document_id == doc2)
+        )
+        assert dv2 is not None
+        dv2.meta = {"title": "beta"}
+        db.commit()
+
+    resp = client.get(
+        "/documents",
+        params={
+            "project_id": "p1",
+            "status": "parsed",
+            "type": "pdf",
+            "q": "alpha",
+        },
+    )
+    body = resp.json()
+    assert len(body["documents"]) == 1
+    assert body["documents"][0]["id"] == doc1
+
+    resp_page1 = client.get(
+        "/documents", params={"project_id": "p1", "limit": 1, "offset": 0}
+    )
+    resp_page2 = client.get(
+        "/documents", params={"project_id": "p1", "limit": 1, "offset": 1}
+    )
+    id1 = resp_page1.json()["documents"][0]["id"]
+    id2 = resp_page2.json()["documents"][0]["id"]
+    assert id1 != id2

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,21 @@
+def test_deduplication(test_app) -> None:
+    client, store, calls, _ = test_app
+    resp = client.post(
+        "/ingest",
+        data={"project_id": "p1"},
+        files={"file": ("doc.txt", b"hello", "text/plain")},
+    )
+    assert resp.status_code == 200
+    doc_id = resp.json()["doc_id"]
+    assert calls == [doc_id]
+    assert len(store.client.store) == 1
+
+    resp2 = client.post(
+        "/ingest",
+        data={"project_id": "p1"},
+        files={"file": ("doc.txt", b"hello", "text/plain")},
+    )
+    assert resp2.status_code == 200
+    assert resp2.json()["doc_id"] == doc_id
+    assert len(store.client.store) == 1
+    assert calls == [doc_id]

--- a/worker/main.py
+++ b/worker/main.py
@@ -7,7 +7,8 @@ app = Celery("worker", broker=settings.redis_url)
 
 
 @app.task
-def noop() -> None:
+def parse_document(doc_id: str) -> None:
+    # Placeholder parse job
     return None
 
 


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and migration for projects, documents, and document versions
- implement `/ingest` with SHA256 dedup, MinIO storage, and parse task enqueue
- expose `/documents` with filters and pagination
- document progress in STATUS.md

## Testing
- `make lint`
- `make test` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689f5a087394832b85ac8655cc10479f