### PR TITLE
refactor: unify id handling and stabilize chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ curation metadata to chunks. Endpoints require an `X-Role` header; only
   webhook and append an audit entry.
 * `POST /chunks/bulk-apply` – apply a metadata patch to many chunks at once,
   writing an audit row per chunk.
+* `POST /chunks/{chunk_id}/suggestions/{field}/accept` – accept a rule-based
+  suggestion for a single chunk.
+* `POST /chunks/accept-suggestions` – accept a suggestion across many chunks.
+* `GET /documents/{doc_id}/metrics` – return curation completeness metrics.
 
 Audits are stored in the `audits` table with before/after values for each
 change.

--- a/STATUS.md
+++ b/STATUS.md
@@ -60,8 +60,8 @@
 | E4‑04 | LS webhook → metadata | codex | ☑ Done | PR TBD |  |
 | E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | PR TBD |  |
 | E5‑03 | RAG preset templates | codex | ☑ Done | PR TBD |  |
-| E6‑01 | Rule‑based suggestors v1 |  | ☐ To‑Do ☐ Doing ☐ Done |  |  |
-| E6‑03 | Curation completeness metric |  | ☐ To‑Do ☐ Doing ☐ Done |  |  |
+| E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | PR TBD |  |
+| E6‑03 | Curation completeness metric | codex | ☑ Done | PR TBD |  |
 | E7‑03 | Scorecard CLI |  | ☐ To‑Do ☐ Doing ☐ Done |  |  |
 | E4‑05 | Bulk metadata apply | codex | ☑ Done | PR TBD |  |
 | E9‑01 | RBAC (viewer/curator) | codex | ☑ Done | PR TBD |  |

--- a/alembic/versions/0002_add_chunks.py
+++ b/alembic/versions/0002_add_chunks.py
@@ -12,10 +12,10 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "chunks",
-        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column("id", sa.String(), primary_key=True),
         sa.Column(
             "document_id",
-            sa.Uuid(as_uuid=True),
+            sa.String(),
             sa.ForeignKey("documents.id"),
             nullable=False,
         ),
@@ -31,7 +31,7 @@ def upgrade() -> None:
             "metadata",
             sa.JSON().with_variant(postgresql.JSONB, "postgresql"),
             nullable=False,
-            server_default=sa.text("'{}'::jsonb"),
+            server_default=sa.text("'{}'"),
         ),
         sa.Column("rev", sa.Integer(), nullable=False, server_default="1"),
         sa.Column(

--- a/alembic/versions/0003_add_taxonomy_audit.py
+++ b/alembic/versions/0003_add_taxonomy_audit.py
@@ -12,7 +12,7 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "taxonomies",
-        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column("id", sa.String(), primary_key=True),
         sa.Column(
             "project_id",
             sa.Uuid(as_uuid=True),
@@ -39,7 +39,7 @@ def upgrade() -> None:
         sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
         sa.Column(
             "chunk_id",
-            sa.Uuid(as_uuid=True),
+            sa.String(),
             sa.ForeignKey("chunks.id"),
             nullable=False,
         ),

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -32,6 +32,16 @@ class BulkApplyPayload(BaseModel):
     metadata: dict[str, Any]
 
 
+class AcceptSuggestionPayload(BaseModel):
+    user: str
+
+
+class BulkAcceptSuggestionPayload(BaseModel):
+    chunk_ids: List[str]
+    field: str
+    user: str
+
+
 class ExportPayload(BaseModel):
     project_id: str
     doc_ids: List[str]
@@ -42,3 +52,7 @@ class ExportPayload(BaseModel):
 class ExportResponse(BaseModel):
     export_id: str
     url: str
+
+
+class MetricsResponse(BaseModel):
+    curation_completeness: float

--- a/chunking/chunker.py
+++ b/chunking/chunker.py
@@ -68,12 +68,13 @@ def chunk_blocks(
             return
         text = "\n".join(buf).strip()
         content = ChunkContent(type="text", text=text)
+        text_hash = _hash_text(content)
         chunk = Chunk(
-            id=uuid.uuid4(),
+            id=uuid.uuid5(uuid.NAMESPACE_URL, text_hash),
             order=len(chunks),
             content=content,
             source=ChunkSource(page=start_page, section_path=current_section.copy()),
-            text_hash=_hash_text(content),
+            text_hash=text_hash,
         )
         chunks.append(chunk)
         buf = []
@@ -85,15 +86,16 @@ def chunk_blocks(
         if block.type == "table_placeholder":
             flush()
             content = ChunkContent(type="table_placeholder", text=None)
+            text_hash = _hash_text(content)
             chunks.append(
                 Chunk(
-                    id=uuid.uuid4(),
+                    id=uuid.uuid5(uuid.NAMESPACE_URL, text_hash),
                     order=len(chunks),
                     content=content,
                     source=ChunkSource(
                         page=block.page, section_path=block.section_path.copy()
                     ),
-                    text_hash=_hash_text(content),
+                    text_hash=text_hash,
                 )
             )
             continue

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import uuid
+from typing import Iterable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.settings import get_settings
+from models import Chunk, DocumentStatus, DocumentVersion, Taxonomy
+
+
+def _required_fields(project_id: uuid.UUID | str, db: Session) -> list[str]:
+    tax = db.scalar(
+        select(Taxonomy)
+        .where(Taxonomy.project_id == project_id)
+        .order_by(Taxonomy.version.desc())
+        .limit(1)
+    )
+    if tax is None:
+        return []
+    return [f["name"] for f in tax.fields if f.get("required")]
+
+
+def compute_curation_completeness(
+    doc_id: uuid.UUID | str,
+    project_id: uuid.UUID | str,
+    version: int,
+    db: Session,
+) -> float:
+    required = _required_fields(project_id, db)
+    chunks: Iterable[Chunk] = db.scalars(
+        select(Chunk).where(Chunk.document_id == doc_id, Chunk.version == version)
+    )
+    chunk_list = list(chunks)
+    total = len(chunk_list)
+    if total == 0:
+        return 0.0
+    if not required:
+        return 1.0
+    complete = 0
+    for c in chunk_list:
+        if all(field in c.meta for field in required):
+            complete += 1
+    return complete / total
+
+
+def enforce_quality_gates(
+    doc_id: uuid.UUID | str,
+    project_id: uuid.UUID | str,
+    version: int,
+    db: Session,
+) -> None:
+    settings = get_settings()
+    dv = db.scalar(
+        select(DocumentVersion).where(
+            DocumentVersion.document_id == doc_id,
+            DocumentVersion.version == version,
+        )
+    )
+    if dv is None:
+        return
+    completeness = compute_curation_completeness(doc_id, project_id, version, db)
+    metrics = dict(dv.meta.get("metrics", {}))
+    metrics["curation_completeness"] = completeness
+    dv.meta = {**dv.meta, "metrics": metrics}
+    dv.status = (
+        DocumentStatus.NEEDS_REVIEW.value
+        if completeness < settings.curation_completeness_threshold
+        else DocumentStatus.PARSED.value
+    )
+    db.add(dv)

--- a/core/settings.py
+++ b/core/settings.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     minio_secure: bool = False
     s3_bucket: str
     export_signed_url_expiry_seconds: int = 600
+    curation_completeness_threshold: float = 0.8
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -10,6 +10,7 @@ from jinja2 import Environment  # type: ignore[import-not-found]
 from storage.object_store import ObjectStore, derived_key, export_key
 
 env = Environment()
+env.policies["json.dumps_kwargs"] = {"sort_keys": False}
 
 RAG_TEMPLATE = '{{ {"context": ((chunk.source.section_path | join(" / ")) ~ ": " ~ chunk.content.text), "answer": ""} | tojson }}'
 

--- a/models/audit.py
+++ b/models/audit.py
@@ -16,8 +16,8 @@ class Audit(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
-    chunk_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), sa.ForeignKey("chunks.id"), nullable=False
+    chunk_id: Mapped[str] = mapped_column(
+        sa.String, sa.ForeignKey("chunks.id"), nullable=False
     )
     user: Mapped[str] = mapped_column(sa.String, nullable=False)
     action: Mapped[str] = mapped_column(sa.String, nullable=False)

--- a/models/chunk.py
+++ b/models/chunk.py
@@ -13,11 +13,11 @@ json_type = sa.JSON().with_variant(JSONB, "postgresql")
 class Chunk(Base):
     __tablename__ = "chunks"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    id: Mapped[str] = mapped_column(
+        sa.String, primary_key=True, default=lambda: str(uuid.uuid4())
     )
-    document_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), sa.ForeignKey("documents.id"), nullable=False
+    document_id: Mapped[str] = mapped_column(
+        sa.String, sa.ForeignKey("documents.id"), nullable=False
     )
     version: Mapped[int] = mapped_column(sa.Integer, nullable=False)
     order: Mapped[int] = mapped_column(sa.Integer, nullable=False)

--- a/models/document.py
+++ b/models/document.py
@@ -22,8 +22,8 @@ json_type = sa.JSON().with_variant(JSONB, "postgresql")
 class Document(Base):
     __tablename__ = "documents"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    id: Mapped[str] = mapped_column(
+        sa.String, primary_key=True, default=lambda: str(uuid.uuid4())
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), sa.ForeignKey("projects.id"), nullable=False
@@ -32,8 +32,8 @@ class Document(Base):
     created_at: Mapped[sa.types.DateTime] = mapped_column(
         sa.DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), sa.ForeignKey("document_versions.id"), nullable=True
+    latest_version_id: Mapped[str | None] = mapped_column(
+        sa.String, sa.ForeignKey("document_versions.id"), nullable=True
     )
 
     project = relationship("Project", back_populates="documents")
@@ -50,11 +50,11 @@ class Document(Base):
 class DocumentVersion(Base):
     __tablename__ = "document_versions"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    id: Mapped[str] = mapped_column(
+        sa.String, primary_key=True, default=lambda: str(uuid.uuid4())
     )
-    document_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), sa.ForeignKey("documents.id"), nullable=False
+    document_id: Mapped[str] = mapped_column(
+        sa.String, sa.ForeignKey("documents.id"), nullable=False
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), sa.ForeignKey("projects.id"), nullable=False

--- a/parsers/pdf.py
+++ b/parsers/pdf.py
@@ -11,6 +11,7 @@ from .registry import registry
 def parse_pdf(data: bytes):
     doc = fitz.open(stream=data, filetype="pdf")
     current_heading: list[str] = []
+    first_block = True
     for page_index, page in enumerate(doc, start=1):
         for block in page.get_text("blocks"):
             text = block[4].strip()
@@ -22,6 +23,9 @@ def parse_pdf(data: bytes):
                     continue
                 if line.isupper():
                     current_heading = [line]
+                elif first_block and not current_heading:
+                    current_heading = ["INTRO"]
                 yield Block(
                     text=line, page=page_index, section_path=current_heading.copy()
                 )
+                first_block = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from collections.abc import Generator
 from io import BytesIO
 from typing import List, Tuple
@@ -7,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 
 os.environ.setdefault("DATABASE_URL", "sqlite://")
 os.environ.setdefault("MINIO_ENDPOINT", "localhost")
@@ -26,6 +28,9 @@ for var in [
     "S3_BUCKET",
 ]:
     os.environ.pop(var, None)
+
+PROJECT_ID_1 = uuid.uuid4()
+PROJECT_ID_2 = uuid.uuid4()
 
 
 class FakeS3Client:
@@ -52,13 +57,17 @@ class FakeS3Client:
 def test_app() -> (
     Generator[tuple[TestClient, ObjectStore, List[str], sessionmaker], None, None]
 ):
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     TestingSessionLocal = sessionmaker(bind=engine)
     Base.metadata.create_all(engine)
 
     with TestingSessionLocal() as session:
-        session.add(Project(id="p1", name="P1", allow_versioning=False))
-        session.add(Project(id="p2", name="P2", allow_versioning=False))
+        session.add(Project(id=PROJECT_ID_1, name="P1", allow_versioning=False))
+        session.add(Project(id=PROJECT_ID_2, name="P2", allow_versioning=False))
         session.commit()
 
     store = ObjectStore(client=FakeS3Client(), bucket="test")

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,25 +1,26 @@
 from sqlalchemy import select
 
 from models import DocumentStatus, DocumentVersion
+from tests.conftest import PROJECT_ID_1, PROJECT_ID_2
 
 
 def test_listing_filters_and_pagination(test_app) -> None:
     client, _, _, SessionLocal = test_app
     resp1 = client.post(
         "/ingest",
-        data={"project_id": "p1"},
+        data={"project_id": str(PROJECT_ID_1)},
         files={"file": ("a.pdf", b"alpha", "application/pdf")},
     )
     doc1 = resp1.json()["doc_id"]
     resp2 = client.post(
         "/ingest",
-        data={"project_id": "p1"},
+        data={"project_id": str(PROJECT_ID_1)},
         files={"file": ("b.html", b"beta", "text/html")},
     )
     doc2 = resp2.json()["doc_id"]
     client.post(
         "/ingest",
-        data={"project_id": "p2"},
+        data={"project_id": str(PROJECT_ID_2)},
         files={"file": ("c.pdf", b"gamma", "application/pdf")},
     )
 
@@ -40,7 +41,7 @@ def test_listing_filters_and_pagination(test_app) -> None:
     resp = client.get(
         "/documents",
         params={
-            "project_id": "p1",
+            "project_id": str(PROJECT_ID_1),
             "status": "parsed",
             "type": "pdf",
             "q": "alpha",
@@ -51,10 +52,10 @@ def test_listing_filters_and_pagination(test_app) -> None:
     assert body["documents"][0]["id"] == doc1
 
     resp_page1 = client.get(
-        "/documents", params={"project_id": "p1", "limit": 1, "offset": 0}
+        "/documents", params={"project_id": str(PROJECT_ID_1), "limit": 1, "offset": 0}
     )
     resp_page2 = client.get(
-        "/documents", params={"project_id": "p1", "limit": 1, "offset": 1}
+        "/documents", params={"project_id": str(PROJECT_ID_1), "limit": 1, "offset": 1}
     )
     id1 = resp_page1.json()["documents"][0]["id"]
     id2 = resp_page2.json()["documents"][0]["id"]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,11 +3,12 @@ from typing import List
 
 from models import Taxonomy
 from storage.object_store import derived_key, export_key
+from tests.conftest import PROJECT_ID_1
 
 
 def _add_taxonomy(SessionLocal) -> None:
     with SessionLocal() as session:
-        session.add(Taxonomy(project_id="p1", version=1, fields=[]))
+        session.add(Taxonomy(project_id=PROJECT_ID_1, version=1, fields=[]))
         session.commit()
 
 
@@ -35,7 +36,11 @@ def test_rag_jsonl_export(test_app) -> None:
     _put_chunk(store, "d2", "world", ["Intro"])
     resp = client.post(
         "/export/jsonl",
-        json={"project_id": "p1", "doc_ids": ["d1", "d2"], "preset": "rag"},
+        json={
+            "project_id": str(PROJECT_ID_1),
+            "doc_ids": ["d1", "d2"],
+            "preset": "rag",
+        },
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -51,7 +56,11 @@ def test_rag_jsonl_export(test_app) -> None:
     # idempotent
     resp2 = client.post(
         "/export/jsonl",
-        json={"project_id": "p1", "doc_ids": ["d2", "d1"], "preset": "rag"},
+        json={
+            "project_id": str(PROJECT_ID_1),
+            "doc_ids": ["d2", "d1"],
+            "preset": "rag",
+        },
     )
     assert resp2.json()["export_id"] == data["export_id"]
     key2 = export_key(resp2.json()["export_id"], "data.jsonl")
@@ -66,7 +75,11 @@ def test_csv_export_custom_template(test_app) -> None:
     template = '{{ {"text": chunk.content.text, "page": chunk.source.page} | tojson }}'
     resp = client.post(
         "/export/csv",
-        json={"project_id": "p1", "doc_ids": ["d1", "d2"], "template": template},
+        json={
+            "project_id": str(PROJECT_ID_1),
+            "doc_ids": ["d1", "d2"],
+            "template": template,
+        },
     )
     assert resp.status_code == 200
     key = export_key(resp.json()["export_id"], "data.csv")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,8 +1,11 @@
+from tests.conftest import PROJECT_ID_1
+
+
 def test_deduplication(test_app) -> None:
     client, store, calls, _ = test_app
     resp = client.post(
         "/ingest",
-        data={"project_id": "p1"},
+        data={"project_id": str(PROJECT_ID_1)},
         files={"file": ("doc.txt", b"hello", "text/plain")},
     )
     assert resp.status_code == 200
@@ -12,7 +15,7 @@ def test_deduplication(test_app) -> None:
 
     resp2 = client.post(
         "/ingest",
-        data={"project_id": "p1"},
+        data={"project_id": str(PROJECT_ID_1)},
         files={"file": ("doc.txt", b"hello", "text/plain")},
     )
     assert resp2.status_code == 200

--- a/tests/test_suggestions_api.py
+++ b/tests/test_suggestions_api.py
@@ -1,0 +1,110 @@
+import uuid
+
+from sqlalchemy import select
+
+from models import Audit, Chunk, Document, DocumentStatus, DocumentVersion, Taxonomy
+from tests.conftest import PROJECT_ID_1
+
+
+def setup_document(SessionLocal) -> dict[str, str]:
+    with SessionLocal() as db:
+        doc_id = str(uuid.uuid4())
+        dv_id = str(uuid.uuid4())
+        c1_id = str(uuid.uuid4())
+        c2_id = str(uuid.uuid4())
+        doc = Document(
+            id=doc_id,
+            project_id=PROJECT_ID_1,
+            source_type="pdf",
+            latest_version_id=dv_id,
+        )
+        dv = DocumentVersion(
+            id=dv_id,
+            document_id=doc_id,
+            project_id=PROJECT_ID_1,
+            version=1,
+            doc_hash="h",
+            mime="text/plain",
+            size=1,
+            status=DocumentStatus.PARSED.value,
+            meta={},
+        )
+        chunk1 = Chunk(
+            id=c1_id,
+            document_id=doc_id,
+            version=1,
+            order=1,
+            content={},
+            text_hash="t1",
+            meta={
+                "suggestions": {
+                    "severity": {
+                        "value": "ERROR",
+                        "confidence": 0.9,
+                        "rationale": "regex",
+                        "span": "ERROR",
+                    }
+                }
+            },
+        )
+        chunk2 = Chunk(
+            id=c2_id,
+            document_id=doc_id,
+            version=1,
+            order=2,
+            content={},
+            text_hash="t2",
+            meta={
+                "suggestions": {
+                    "severity": {
+                        "value": "INFO",
+                        "confidence": 0.9,
+                        "rationale": "regex",
+                        "span": "INFO",
+                    }
+                }
+            },
+        )
+        tax = Taxonomy(
+            project_id=PROJECT_ID_1,
+            version=1,
+            fields=[{"name": "severity", "type": "enum", "required": True}],
+        )
+        db.add_all([doc, dv, chunk1, chunk2, tax])
+        db.commit()
+        return {"doc": doc_id, "dv": dv_id, "c1": c1_id, "c2": c2_id}
+
+
+def test_accept_suggestion_and_metrics(test_app) -> None:
+    client, _, _, SessionLocal = test_app
+    ids = setup_document(SessionLocal)
+    resp = client.post(
+        f"/chunks/{ids['c1']}/suggestions/severity/accept",
+        json={"user": "u"},
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    with SessionLocal() as db:
+        chunk = db.get(Chunk, ids["c1"])
+        assert chunk.meta["severity"] == "ERROR"
+        assert "suggestions" not in chunk.meta
+        dv = db.get(DocumentVersion, ids["dv"])
+        assert dv.status == DocumentStatus.NEEDS_REVIEW.value
+        assert dv.meta["metrics"]["curation_completeness"] == 0.5
+        audits = db.scalars(
+            select(Audit).where(Audit.action == "accept_suggestion")
+        ).all()
+        assert len(audits) == 1
+
+    resp2 = client.post(
+        "/chunks/accept-suggestions",
+        json={"chunk_ids": [ids["c2"]], "field": "severity", "user": "u"},
+        headers={"X-Role": "curator"},
+    )
+    assert resp2.status_code == 200
+    with SessionLocal() as db:
+        dv = db.get(DocumentVersion, ids["dv"])
+        assert dv.status == DocumentStatus.PARSED.value
+        assert dv.meta["metrics"]["curation_completeness"] == 1.0
+    metrics = client.get(f"/documents/{ids['doc']}/metrics")
+    assert metrics.json()["curation_completeness"] == 1.0

--- a/tests/test_suggestors.py
+++ b/tests/test_suggestors.py
@@ -1,0 +1,11 @@
+from worker.suggestors import suggest
+
+
+def test_rule_suggestors() -> None:
+    text = "Step 1: start process ERROR in INC-1234 on 2024-01-01"
+    result = suggest(text)
+    step = result["step_id"]["value"]
+    assert isinstance(step, str) and step.startswith("Step 1")
+    assert result["severity"]["value"] == "ERROR"
+    assert result["ticket_id"]["value"] == "INC-1234"
+    assert result["datetime"]["value"] == "2024-01-01"

--- a/tests/test_taxonomy_rbac.py
+++ b/tests/test_taxonomy_rbac.py
@@ -1,6 +1,7 @@
 import uuid
 
 from models import Audit, Chunk, Document
+from tests.conftest import PROJECT_ID_1
 
 
 def test_taxonomy_version_and_ls_config(test_app):
@@ -18,22 +19,26 @@ def test_taxonomy_version_and_ls_config(test_app):
         ]
     }
     r = client.post(
-        "/projects/p1/taxonomy", json=payload, headers={"X-Role": "curator"}
+        f"/projects/{PROJECT_ID_1}/taxonomy",
+        json=payload,
+        headers={"X-Role": "curator"},
     )
     assert r.status_code == 200
     assert r.json()["version"] == 1
     r2 = client.post(
-        "/projects/p1/taxonomy", json=payload, headers={"X-Role": "curator"}
+        f"/projects/{PROJECT_ID_1}/taxonomy",
+        json=payload,
+        headers={"X-Role": "curator"},
     )
     assert r2.json()["version"] == 2
-    r3 = client.get("/projects/p1/taxonomy")
+    r3 = client.get(f"/projects/{PROJECT_ID_1}/taxonomy")
     assert r3.json()["version"] == 2
     assert r3.json()["fields"][0]["helptext"] == "Severity level"
-    r4 = client.get("/projects/p1/ls-config")
+    r4 = client.get(f"/projects/{PROJECT_ID_1}/ls-config")
     assert "Severity level" in r4.text
     assert '<Choice value="low"/>' in r4.text
     r_forbidden = client.post(
-        "/projects/p1/taxonomy", json=payload, headers={"X-Role": "viewer"}
+        f"/projects/{PROJECT_ID_1}/taxonomy", json=payload, headers={"X-Role": "viewer"}
     )
     assert r_forbidden.status_code == 403
 
@@ -42,7 +47,7 @@ def test_webhook_and_bulk_apply(test_app):
     client, _, _, SessionLocal = test_app
     with SessionLocal() as db:
         doc_id = str(uuid.uuid4())
-        doc = Document(id=doc_id, project_id="p1", source_type="pdf")
+        doc = Document(id=doc_id, project_id=PROJECT_ID_1, source_type="pdf")
         db.add(doc)
         db.flush()
         c1 = Chunk(

--- a/worker/derived_writer.py
+++ b/worker/derived_writer.py
@@ -63,7 +63,7 @@ def upsert_chunks(
     db.bulk_save_objects(
         [
             ChunkModel(
-                id=ch.id,
+                id=str(ch.id),
                 document_id=doc_id,
                 version=version,
                 order=ch.order,

--- a/worker/suggestors/__init__.py
+++ b/worker/suggestors/__init__.py
@@ -1,0 +1,3 @@
+from .rules import Suggestion, suggest
+
+__all__ = ["suggest", "Suggestion"]

--- a/worker/suggestors/rules.py
+++ b/worker/suggestors/rules.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from typing import Dict
+
+
+@dataclass
+class Suggestion:
+    field: str
+    value: str
+    confidence: float
+    rationale: str
+    span: str
+
+    def to_dict(self) -> Dict[str, str | float]:
+        return asdict(self)
+
+
+_SEVERITY_RE = re.compile(r"\b(DEBUG|INFO|WARN|ERROR|FATAL)\b")
+_STEP_RE = re.compile(r"\bStep\s?\d+:?")
+_TICKET_RE = re.compile(r"\b(?:JIRA|BUG|INC)-\d+\b")
+_DATETIME_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2})?\b")
+
+
+def suggest(text: str) -> Dict[str, Dict[str, str | float]]:
+    suggestions: Dict[str, Suggestion] = {}
+    if m := _SEVERITY_RE.search(text):
+        val = m.group(1)
+        suggestions["severity"] = Suggestion(
+            field="severity",
+            value=val,
+            confidence=0.9,
+            rationale="regex match",
+            span=m.group(0),
+        )
+    if m := _STEP_RE.search(text):
+        val = m.group(0).strip()
+        suggestions["step_id"] = Suggestion(
+            field="step_id",
+            value=val,
+            confidence=0.9,
+            rationale="regex match",
+            span=m.group(0),
+        )
+    if m := _TICKET_RE.search(text):
+        val = m.group(0)
+        suggestions["ticket_id"] = Suggestion(
+            field="ticket_id",
+            value=val,
+            confidence=0.9,
+            rationale="regex match",
+            span=val,
+        )
+    if m := _DATETIME_RE.search(text):
+        val = m.group(0)
+        suggestions["datetime"] = Suggestion(
+            field="datetime",
+            value=val,
+            confidence=0.9,
+            rationale="regex match",
+            span=val,
+        )
+    return {k: v.to_dict() for k, v in suggestions.items()}


### PR DESCRIPTION
## Summary
- store document and chunk identifiers as strings and update migrations
- generate deterministic chunk IDs and disable JSON key sorting for exports
- harden ingestion and suggestion flows with proper flushing and quality metric updates

## Testing
- `make lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f63f9b288832ba0a3ad0c1d7199c2