### PR TITLE
feat: add document retrieval endpoints

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -52,6 +52,7 @@
 | E2-02 | Document registry schema | codex | ☑ Done | PR TBD |  |
 | E2-03 | /ingest endpoint | codex | ☑ Done | PR TBD |  |
 | E2-04 | Document list & filters | codex | ☑ Done | PR TBD |  |
+| E2-05 | Document detail & chunks retrieval | codex | ☑ Done | PR TBD |  |
 | E3‑03 | PDF parser v1 | codex | ☑ Done | PR TBD |  |
 | E3‑04 | HTML parser v1 | codex | ☑ Done | PR TBD |  |
 | E3‑05 | Derived writer & DB batcher | codex | ☑ Done | PR TBD |  |

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,7 +1,9 @@
 from sqlalchemy import select
 
+from chunking.chunker import Block, chunk_blocks
 from models import DocumentStatus, DocumentVersion
 from tests.conftest import PROJECT_ID_1, PROJECT_ID_2
+from worker.derived_writer import upsert_chunks
 
 
 def test_listing_filters_and_pagination(test_app) -> None:
@@ -60,3 +62,34 @@ def test_listing_filters_and_pagination(test_app) -> None:
     id1 = resp_page1.json()["documents"][0]["id"]
     id2 = resp_page2.json()["documents"][0]["id"]
     assert id1 != id2
+
+
+def test_get_document_and_chunks(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("doc.txt", b"hello world", "text/plain")},
+    )
+    doc_id = resp.json()["doc_id"]
+
+    blocks = [Block(text="hello world", page=1)]
+    chunks = chunk_blocks(blocks, min_tokens=1, max_tokens=5)
+
+    with SessionLocal() as db:
+        dv = db.scalar(
+            select(DocumentVersion).where(DocumentVersion.document_id == doc_id)
+        )
+        assert dv is not None
+        dv.status = DocumentStatus.PARSED.value
+        db.commit()
+        upsert_chunks(db, store, doc_id=doc_id, version=1, chunks=chunks)
+
+    resp_doc = client.get(f"/documents/{doc_id}")
+    assert resp_doc.status_code == 200
+    assert resp_doc.json()["id"] == doc_id
+
+    resp_chunks = client.get(f"/documents/{doc_id}/chunks")
+    data = resp_chunks.json()
+    assert data["total"] == 1
+    assert data["chunks"][0]["content"]["text"] == "hello world"


### PR DESCRIPTION
## Summary
- handle document detail requests with new `/documents/{doc_id}` route
- expose `/documents/{doc_id}/chunks` with filtering and pagination
- test document detail and chunk listing, update project status

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f9b3c3f18832bb8ea64ef0c8f10e2