### PR TITLE
Persist filename and robust parsing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -70,6 +70,7 @@
 | E9‑02 | Project settings: engine toggles & cost guards | codex | ☑ Done | PR TBD |  |
 | E9‑03 | Signed URL policy | codex | ☑ Done | PR TBD |  |
 | E9-04 | Project onboarding API | codex | ☑ Done | PR TBD |  |
+| E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -232,7 +232,7 @@ async def ingest(
         mime=mime,
         size=len(data),
         status=DocumentStatus.INGESTED.value,
-        meta={},
+        meta={"filename": filename},
     )
     db.add(version)
     db.flush()

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,0 +1,5 @@
+from . import html as _html  # noqa: F401
+from . import pdf as _pdf  # noqa: F401
+from .registry import registry
+
+__all__ = ["registry"]

--- a/parsers/html.py
+++ b/parsers/html.py
@@ -4,45 +4,52 @@ from bs4 import BeautifulSoup, NavigableString, Tag  # type: ignore[import-untyp
 
 from chunking.chunker import Block
 
-from .registry import registry
+from .registry import Parser, registry
 
 
-@registry.register("html")
-def parse_html(data: bytes):
-    soup = BeautifulSoup(data, "html.parser")
-    for tag in soup.find_all(["nav", "footer", "aside"]):
-        tag.decompose()
-    stack: list[str] = []
+@registry.register("text/html")
+class HTMLParser:
+    @staticmethod
+    def parse(data: bytes):
+        soup = BeautifulSoup(data, "html.parser")
+        for tag in soup.find_all(["nav", "footer", "aside"]):
+            tag.decompose()
+        stack: list[str] = []
 
-    def traverse(node) -> "list[Block]":
-        blocks = []
-        for child in node.children:
-            if isinstance(child, NavigableString):
-                text = str(child).strip()
-                if text:
-                    blocks.append(Block(text=text, section_path=stack.copy()))
-            elif isinstance(child, Tag):
-                name = child.name.lower()
-                if name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
-                    level = int(name[1])
-                    text = child.get_text(" ", strip=True)
-                    stack[:] = stack[: level - 1]
-                    stack.append(text)
-                    blocks.append(Block(text=text, section_path=stack.copy()))
-                elif name == "table":
-                    blocks.append(
-                        Block(
-                            type="table_placeholder", text="", section_path=stack.copy()
-                        )
-                    )
-                elif name == "pre":
-                    text = child.get_text("", strip=False)
+        def traverse(node) -> "list[Block]":
+            blocks = []
+            for child in node.children:
+                if isinstance(child, NavigableString):
+                    text = str(child).strip()
                     if text:
                         blocks.append(Block(text=text, section_path=stack.copy()))
-                else:
-                    blocks.extend(traverse(child))
-        return blocks
+                elif isinstance(child, Tag):
+                    name = child.name.lower()
+                    if name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+                        level = int(name[1])
+                        text = child.get_text(" ", strip=True)
+                        stack[:] = stack[: level - 1]
+                        stack.append(text)
+                        blocks.append(Block(text=text, section_path=stack.copy()))
+                    elif name == "table":
+                        blocks.append(
+                            Block(
+                                type="table_placeholder",
+                                text="",
+                                section_path=stack.copy(),
+                            )
+                        )
+                    elif name == "pre":
+                        text = child.get_text("", strip=False)
+                        if text:
+                            blocks.append(Block(text=text, section_path=stack.copy()))
+                    else:
+                        blocks.extend(traverse(child))
+            return blocks
 
-    body = soup.body or soup
-    for blk in traverse(body):
-        yield blk
+        body = soup.body or soup
+        for blk in traverse(body):
+            yield blk
+
+
+__all__ = ["HTMLParser"]

--- a/parsers/pdf.py
+++ b/parsers/pdf.py
@@ -4,28 +4,33 @@ import fitz  # type: ignore[import-not-found, import-untyped]
 
 from chunking.chunker import Block
 
-from .registry import registry
+from .registry import Parser, registry
 
 
-@registry.register("pdf")
-def parse_pdf(data: bytes):
-    doc = fitz.open(stream=data, filetype="pdf")
-    current_heading: list[str] = []
-    first_block = True
-    for page_index, page in enumerate(doc, start=1):
-        for block in page.get_text("blocks"):
-            text = block[4].strip()
-            if not text:
-                continue
-            for line in text.splitlines():
-                line = line.strip()
-                if not line:
+@registry.register("application/pdf")
+class PDFParser:
+    @staticmethod
+    def parse(data: bytes):
+        doc = fitz.open(stream=data, filetype="pdf")
+        current_heading: list[str] = []
+        first_block = True
+        for page_index, page in enumerate(doc, start=1):
+            for block in page.get_text("blocks"):
+                text = block[4].strip()
+                if not text:
                     continue
-                if line.isupper():
-                    current_heading = [line]
-                elif first_block and not current_heading:
-                    current_heading = ["INTRO"]
-                yield Block(
-                    text=line, page=page_index, section_path=current_heading.copy()
-                )
-                first_block = False
+                for line in text.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    if line.isupper():
+                        current_heading = [line]
+                    elif first_block and not current_heading:
+                        current_heading = ["INTRO"]
+                    yield Block(
+                        text=line, page=page_index, section_path=current_heading.copy()
+                    )
+                    first_block = False
+
+
+__all__ = ["PDFParser"]

--- a/parsers/registry.py
+++ b/parsers/registry.py
@@ -1,33 +1,32 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, Iterable
+from typing import Callable, Dict, Iterable, Protocol, Type
 
 from chunking.chunker import Block
 
 
+class Parser(Protocol):
+    @staticmethod
+    def parse(data: bytes) -> Iterable[Block]: ...
+
+
 class ParserRegistry:
     def __init__(self) -> None:
-        self._parsers: Dict[str, Callable[[bytes], Iterable[Block]]] = {}
+        self._parsers: Dict[str, Type[Parser]] = {}
 
-    def register(
-        self, source_type: str
-    ) -> Callable[
-        [Callable[[bytes], Iterable[Block]]], Callable[[bytes], Iterable[Block]]
-    ]:
-        def decorator(
-            func: Callable[[bytes], Iterable[Block]],
-        ) -> Callable[[bytes], Iterable[Block]]:
-            self._parsers[source_type] = func
-            return func
+    def register(self, mime: str) -> Callable[[Type[Parser]], Type[Parser]]:
+        def decorator(cls: Type[Parser]) -> Type[Parser]:
+            self._parsers[mime] = cls
+            return cls
 
         return decorator
 
-    def get(self, source_type: str) -> Callable[[bytes], Iterable[Block]]:
-        if source_type not in self._parsers:
-            raise ValueError(f"No parser registered for {source_type}")
-        return self._parsers[source_type]
+    def get(self, mime: str) -> Type[Parser]:
+        if mime not in self._parsers:
+            raise ValueError(f"No parser registered for {mime}")
+        return self._parsers[mime]
 
 
 registry = ParserRegistry()
 
-__all__ = ["registry", "ParserRegistry"]
+__all__ = ["registry", "ParserRegistry", "Parser"]

--- a/storage/object_store.py
+++ b/storage/object_store.py
@@ -58,3 +58,12 @@ class ObjectStore:
         return self.client.generate_presigned_url(
             "put_object", Params={"Bucket": self.bucket, "Key": key}, ExpiresIn=expiry
         )
+
+
+__all__ = [
+    "ObjectStore",
+    "create_client",
+    "raw_key",
+    "derived_key",
+    "export_key",
+]

--- a/tests/test_worker_parse.py
+++ b/tests/test_worker_parse.py
@@ -1,0 +1,63 @@
+import pathlib
+
+import sqlalchemy as sa
+
+from models import DocumentVersion
+from storage.object_store import derived_key
+from tests.conftest import PROJECT_ID_1
+from worker import main as worker_main
+
+BASE = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _setup_worker(store, SessionLocal):
+    worker_main.create_client = lambda **kwargs: store.client
+    worker_main.settings.s3_bucket = store.bucket
+    worker_main.SessionLocal = SessionLocal
+
+
+def test_parse_pdf_and_write_chunks(test_app):
+    client, store, _, SessionLocal = test_app
+    _setup_worker(store, SessionLocal)
+
+    data = (BASE / "examples/golden/sample.pdf").read_bytes()
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("sample.pdf", data, "application/pdf")},
+    )
+    doc_id = resp.json()["doc_id"]
+
+    worker_main.parse_document(doc_id)
+
+    resp_chunks = client.get(f"/documents/{doc_id}/chunks")
+    assert resp_chunks.json()["total"] > 0
+    key = derived_key(doc_id, "chunks.jsonl")
+    assert key in store.client.store
+
+
+def test_parse_failure_sets_status(test_app):
+    client, store, _, SessionLocal = test_app
+    _setup_worker(store, SessionLocal)
+
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("x.bin", b"data", "application/octet-stream")},
+    )
+    doc_id = resp.json()["doc_id"]
+
+    with SessionLocal() as db:
+        dv = db.scalar(
+            sa.select(DocumentVersion).where(DocumentVersion.document_id == doc_id)
+        )
+        assert dv is not None
+        dv.mime = "application/x-unknown"
+        db.commit()
+
+    worker_main.parse_document(doc_id)
+
+    resp_doc = client.get(f"/documents/{doc_id}")
+    body = resp_doc.json()
+    assert body["status"] == "failed"
+    assert "error" in body["metadata"]

--- a/worker/main.py
+++ b/worker/main.py
@@ -1,17 +1,69 @@
-from celery import Celery  # type: ignore[import-untyped]
+from __future__ import annotations
 
+import logging
+from typing import Any
+
+import sqlalchemy as sa
+from celery import Celery  # type: ignore[import-untyped]
+from sqlalchemy.orm import sessionmaker
+
+from chunking.chunker import chunk_blocks
 from core.correlation import set_request_id
 from core.settings import get_settings
+from models import Document, DocumentStatus
+from parsers import registry
+from storage.object_store import ObjectStore, create_client, raw_key
+from worker.derived_writer import upsert_chunks
 
 settings = get_settings()
 app = Celery("worker", broker=settings.redis_url)
+engine = sa.create_engine(settings.database_url)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+logger = logging.getLogger(__name__)
+
+
+def _get_store() -> ObjectStore:
+    client = create_client(
+        endpoint=settings.minio_endpoint,
+        access_key=settings.minio_access_key,
+        secret_key=settings.minio_secret_key,
+        secure=settings.minio_secure,
+    )
+    return ObjectStore(client=client, bucket=settings.s3_bucket)
 
 
 @app.task
 def parse_document(doc_id: str, request_id: str | None = None) -> None:
-    """Placeholder parse job that receives a correlation id."""
     set_request_id(request_id)
-    return None
+    store = _get_store()
+    with SessionLocal() as db:
+        doc = db.get(Document, doc_id)
+        if doc is None or doc.latest_version is None:
+            return
+        ver = doc.latest_version
+        filename = ver.meta.get("filename")
+        try:
+            data = store.get_bytes(raw_key(doc_id, filename))
+            parser_cls = registry.get(ver.mime)
+            logger.info("Picked parser: %s for %s", parser_cls.__name__, ver.mime)
+            blocks = parser_cls.parse(data)
+            chunks = chunk_blocks(blocks)
+            upsert_chunks(
+                db,
+                store,
+                doc_id=doc_id,
+                version=ver.version,
+                chunks=chunks,
+            )
+            ver.status = DocumentStatus.PARSED.value
+            db.commit()
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("parse failed: %s", exc)
+            ver.status = DocumentStatus.FAILED.value
+            meta: dict[str, Any] = dict(ver.meta or {})
+            meta["error"] = str(exc)
+            ver.meta = meta
+            db.commit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retain uploaded filename in document metadata and use it for worker parsing
- register PDF/HTML parser classes by MIME type and log selected parser
- parse worker writes chunks & derived JSONL, updating status and errors

## Testing
- `make lint` *(mypy: Interrupted)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689fa4427b90832b9eb31f9dc472cfc1