### PR TITLE
[E4-02] Guidelines endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ curation metadata to chunks. Endpoints require an `X-Role` header; only
 * `POST /projects` – create a new project and return its `id`.
 * `PUT /projects/{project_id}/taxonomy` – create a new taxonomy version with
   field definitions including `helptext` and `examples`.
+* `GET /projects/{project_id}/taxonomy/guidelines` – return labeling guidelines
+  (JSON or markdown) for the active taxonomy.
 * `GET /projects/{project_id}/ls-config` – render a Label Studio configuration
   from the active taxonomy.
 * `POST /webhooks/label-studio` – apply a metadata patch from a Label Studio

--- a/STATUS.md
+++ b/STATUS.md
@@ -57,6 +57,7 @@
 | E3‑04 | HTML parser v1 | codex | ☑ Done | PR TBD |  |
 | E3‑05 | Derived writer & DB batcher | codex | ☑ Done | PR TBD |  |
 | E4‑01 | Taxonomy service v1 | codex | ☑ Done | [PR](#) |  |
+| E4‑02 | Guidelines endpoint | codex | ☑ Done | [PR](#) |  |
 | E4‑03 | LS project config | codex | ☑ Done | PR TBD |  |
 | E4‑04 | LS webhook → metadata | codex | ☑ Done | PR TBD |  |
 | E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | PR TBD |  |

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -20,6 +20,14 @@ class TaxonomyResponse(TaxonomyCreate):
     version: int
 
 
+class GuidelineField(BaseModel):
+    field: str
+    type: Literal["string", "enum", "bool", "number", "date"]
+    required: bool = False
+    helptext: str | None = None
+    examples: List[str] | None = None
+
+
 class WebhookPayload(BaseModel):
     chunk_id: str
     user: str

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -1,0 +1,37 @@
+from tests.conftest import PROJECT_ID_1
+
+
+def test_guidelines_endpoint(test_app):
+    client, _, _, _ = test_app
+    payload = {
+        "fields": [
+            {
+                "name": "severity",
+                "type": "enum",
+                "required": True,
+                "helptext": "Severity level",
+                "examples": ["low", "high"],
+                "options": ["low", "high"],
+            }
+        ]
+    }
+    r = client.put(
+        f"/projects/{PROJECT_ID_1}/taxonomy",
+        json=payload,
+        headers={"X-Role": "curator"},
+    )
+    assert r.status_code == 200
+
+    r_json = client.get(f"/projects/{PROJECT_ID_1}/taxonomy/guidelines")
+    assert r_json.status_code == 200
+    body = r_json.json()
+    assert body[0]["helptext"] == "Severity level"
+    assert "low" in body[0]["examples"]
+
+    r_text = client.get(
+        f"/projects/{PROJECT_ID_1}/taxonomy/guidelines",
+        headers={"Accept": "text/plain"},
+    )
+    assert r_text.status_code == 200
+    assert "Severity level" in r_text.text
+    assert "- low" in r_text.text


### PR DESCRIPTION
## Summary
- expose labeling guidelines for taxonomy fields in JSON or markdown
- document and test new taxonomy guidelines endpoint

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a0a156baa0832b9e7d2328ba2f5edb