### PR TITLE
[E4-03] LS config generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ curation metadata to chunks. Endpoints require an `X-Role` header; only
   field definitions including `helptext` and `examples`.
 * `GET /projects/{project_id}/taxonomy/guidelines` – return labeling guidelines
   (JSON or markdown) for the active taxonomy.
-* `GET /projects/{project_id}/ls-config` – render a Label Studio configuration
-  from the active taxonomy.
+* `POST /label-studio/config?project_id=...` – render a Label Studio project configuration from the active taxonomy; paste the XML into Label Studio's "Labeling configuration" panel under Settings → Labeling Interface.
 * `POST /webhooks/label-studio` – apply a metadata patch from a Label Studio
   webhook and append an audit entry.
 * `POST /chunks/bulk-apply` – apply a metadata patch to many chunks at once,

--- a/STATUS.md
+++ b/STATUS.md
@@ -58,7 +58,7 @@
 | E3‑05 | Derived writer & DB batcher | codex | ☑ Done | PR TBD |  |
 | E4‑01 | Taxonomy service v1 | codex | ☑ Done | [PR](#) |  |
 | E4‑02 | Guidelines endpoint | codex | ☑ Done | [PR](#) |  |
-| E4‑03 | LS project config | codex | ☑ Done | PR TBD |  |
+| E4‑03 | LS project config | codex | ☑ Done | [PR](#) |  |
 | E4‑04 | LS webhook → metadata | codex | ☑ Done | PR TBD |  |
 | E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | PR TBD |  |
 | E5‑03 | RAG preset templates | codex | ☑ Done | PR TBD |  |

--- a/label_studio/config.py
+++ b/label_studio/config.py
@@ -1,0 +1,32 @@
+"""Helpers for generating Label Studio configuration XML."""
+
+from typing import Any, Iterable, Mapping
+
+
+def build_ls_config(fields: Iterable[Mapping[str, Any]]) -> str:
+    """Render a Label Studio project configuration from taxonomy fields."""
+    lines: list[str] = ["<View>", '<Text name="text" value="$text"/>']
+    for field in fields:
+        helptext = str(field.get("helptext") or "")
+        examples: Iterable[str] = field.get("examples") or []
+        help_lines: list[str] = []
+        if helptext:
+            help_lines.append(f"<Help>{helptext}</Help>")
+        for ex in examples:
+            help_lines.append(f"<Example>{ex}</Example>")
+        if field["type"] == "enum":
+            lines.append(f'<Choices name="{field["name"]}" toName="text">')
+            lines.extend(help_lines)
+            options: Iterable[str] = field.get("options") or []
+            for opt in options:
+                lines.append(f'<Choice value="{opt}"/>')
+            lines.append("</Choices>")
+        else:
+            lines.append(f'<TextArea name="{field["name"]}" toName="text">')
+            lines.extend(help_lines)
+            lines.append("</TextArea>")
+    lines.append("</View>")
+    return "\n".join(lines)
+
+
+__all__ = ["build_ls_config"]

--- a/tests/test_ls_config.py
+++ b/tests/test_ls_config.py
@@ -1,0 +1,49 @@
+from tests.conftest import PROJECT_ID_1
+
+EXPECTED_XML = """<View>
+<Text name="text" value="$text"/>
+<Choices name="severity" toName="text">
+<Help>Severity level</Help>
+<Example>low</Example>
+<Example>high</Example>
+<Choice value="low"/>
+<Choice value="high"/>
+</Choices>
+<TextArea name="notes" toName="text">
+</TextArea>
+</View>"""
+
+
+def test_ls_config_snapshot(test_app):
+    client, _, _, _ = test_app
+    payload = {
+        "fields": [
+            {
+                "name": "severity",
+                "type": "enum",
+                "required": True,
+                "helptext": "Severity level",
+                "examples": ["low", "high"],
+                "options": ["low", "high"],
+            },
+            {"name": "notes", "type": "string"},
+        ]
+    }
+    r = client.put(
+        f"/projects/{PROJECT_ID_1}/taxonomy",
+        json=payload,
+        headers={"X-Role": "curator"},
+    )
+    assert r.status_code == 200
+    xml = client.post(
+        "/label-studio/config",
+        params={"project_id": PROJECT_ID_1},
+    )
+    assert xml.status_code == 200
+    assert xml.text == EXPECTED_XML
+
+
+def test_ls_config_missing_taxonomy(test_app):
+    client, _, _, _ = test_app
+    r = client.post("/label-studio/config", params={"project_id": PROJECT_ID_1})
+    assert r.status_code == 400

--- a/tests/test_taxonomy_rbac.py
+++ b/tests/test_taxonomy_rbac.py
@@ -34,7 +34,8 @@ def test_taxonomy_version_and_ls_config(test_app):
     r3 = client.get(f"/projects/{PROJECT_ID_1}/taxonomy")
     assert r3.json()["version"] == 2
     assert r3.json()["fields"][0]["helptext"] == "Severity level"
-    r4 = client.get(f"/projects/{PROJECT_ID_1}/ls-config")
+    r4 = client.post("/label-studio/config", params={"project_id": PROJECT_ID_1})
+    assert r4.status_code == 200
     assert "Severity level" in r4.text
     assert '<Choice value="low"/>' in r4.text
     r_forbidden = client.put(


### PR DESCRIPTION
## Summary
- add standalone Label Studio config builder
- expose POST /label-studio/config to render project XML
- document how to paste config into Label Studio

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a495e00c832ba2e147f0ec7f6274