### PR TITLE
[E4-04] LS webhook

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -59,7 +59,7 @@
 | E4‑01 | Taxonomy service v1 | codex | ☑ Done | [PR](#) |  |
 | E4‑02 | Guidelines endpoint | codex | ☑ Done | [PR](#) |  |
 | E4‑03 | LS project config | codex | ☑ Done | [PR](#) |  |
-| E4‑04 | LS webhook → metadata | codex | ☑ Done | PR TBD |  |
+| E4‑04 | LS webhook → metadata | codex | ☑ Done | [PR](#) |  |
 | E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | PR TBD |  |
 | E5‑03 | RAG preset templates | codex | ☑ Done | PR TBD |  |
 | E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | PR TBD |  |

--- a/api/main.py
+++ b/api/main.py
@@ -458,11 +458,11 @@ def label_studio_webhook(
     if chunk is None:
         raise HTTPException(status_code=404, detail="chunk not found")
     before = dict(chunk.meta)
-    new_meta = dict(chunk.meta)
-    new_meta.update(payload.metadata)
+    new_meta = {**before, **payload.metadata}
+    if new_meta == before:
+        return {"status": "ok"}
     chunk.meta = new_meta
     chunk.rev += 1
-    db.flush()
     audit = Audit(
         chunk_id=chunk.id,
         user=payload.user,

--- a/tests/test_ls_webhook.py
+++ b/tests/test_ls_webhook.py
@@ -1,0 +1,59 @@
+import uuid
+
+from models import Audit, Chunk, Document
+from tests.conftest import PROJECT_ID_1
+
+
+def _setup_chunk(SessionLocal) -> str:
+    with SessionLocal() as db:
+        doc_id = str(uuid.uuid4())
+        doc = Document(id=doc_id, project_id=PROJECT_ID_1, source_type="pdf")
+        db.add(doc)
+        db.flush()
+        chunk = Chunk(
+            id="c1",
+            document_id=doc_id,
+            version=1,
+            order=1,
+            content={},
+            text_hash="t1",
+            meta={},
+        )
+        db.add(chunk)
+        db.commit()
+    return "c1"
+
+
+def test_webhook_forbidden_for_viewer(test_app):
+    client, _, _, SessionLocal = test_app
+    _setup_chunk(SessionLocal)
+    r = client.post(
+        "/webhooks/label-studio",
+        json={"chunk_id": "c1", "user": "u", "metadata": {"severity": "high"}},
+        headers={"X-Role": "viewer"},
+    )
+    assert r.status_code == 403
+
+
+def test_webhook_idempotent(test_app):
+    client, _, _, SessionLocal = test_app
+    _setup_chunk(SessionLocal)
+    payload = {"chunk_id": "c1", "user": "u", "metadata": {"severity": "high"}}
+    r1 = client.post(
+        "/webhooks/label-studio",
+        json=payload,
+        headers={"X-Role": "curator"},
+    )
+    assert r1.status_code == 200
+    r2 = client.post(
+        "/webhooks/label-studio",
+        json=payload,
+        headers={"X-Role": "curator"},
+    )
+    assert r2.status_code == 200
+    with SessionLocal() as db:
+        chunk = db.get(Chunk, "c1")
+        assert chunk.meta["severity"] == "high"
+        assert chunk.rev == 2
+        audits = db.query(Audit).filter_by(chunk_id="c1").all()
+        assert len(audits) == 1


### PR DESCRIPTION
## Summary
- make LS webhook idempotent and restricted to curators
- audit chunk metadata updates and bump revision once
- test Label Studio webhook for idempotency and RBAC

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a86f480c832b8f96859423679d51