### PR TITLE
[E5-01] Template DSL with Jinja2 sandbox

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -60,6 +60,7 @@
 | E4‑02 | Guidelines endpoint | codex | ☑ Done | [PR](#) |  |
 | E4‑03 | LS project config | codex | ☑ Done | [PR](#) |  |
 | E4‑04 | LS webhook → metadata | codex | ☑ Done | [PR](#) |  |
+| E5‑01 | Template DSL (Jinja2) | codex | ☑ Done | [PR](#) |  |
 | E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | PR TBD |  |
 | E5‑03 | RAG preset templates | codex | ☑ Done | PR TBD |  |
 | E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | PR TBD |  |

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -5,12 +5,9 @@ import json
 import subprocess
 from typing import Iterable, List, Tuple
 
-from jinja2 import Environment  # type: ignore[import-not-found]
-
 from storage.object_store import ObjectStore, derived_key, export_key
 
-env = Environment()
-env.policies["json.dumps_kwargs"] = {"sort_keys": False}
+from .templates import compile_template
 
 RAG_TEMPLATE = '{{ {"context": ((chunk.source.section_path | join(" / ")) ~ ": " ~ chunk.content.text), "answer": ""} | tojson }}'
 
@@ -91,7 +88,7 @@ def export_jsonl(
     expiry: int,
 ) -> Tuple[str, str]:
     template_str = _get_template(template, preset)
-    tmpl = env.from_string(template_str)
+    tmpl = compile_template(template_str)
     export_id, template_hash, doc_ids_sorted = _compute_export_id(
         "jsonl", doc_ids, taxonomy_version, template_str
     )
@@ -120,7 +117,7 @@ def export_csv(
     expiry: int,
 ) -> Tuple[str, str]:
     template_str = _get_template(template, preset)
-    tmpl = env.from_string(template_str)
+    tmpl = compile_template(template_str)
     export_id, template_hash, doc_ids_sorted = _compute_export_id(
         "csv", doc_ids, taxonomy_version, template_str
     )

--- a/exporters/helpers.py
+++ b/exporters/helpers.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Mapping, Sequence
+
+
+def join_section_path(meta: Mapping[str, Sequence[str] | None]) -> str:
+    """Join a section path list into a string."""
+    path = meta.get("section_path") or []
+    return " / ".join(path)
+
+
+def iso8601(dt: datetime | date) -> str:
+    """Return ISO-8601 string for date or datetime."""
+    return dt.isoformat()
+
+
+__all__ = ["join_section_path", "iso8601"]

--- a/exporters/templates.py
+++ b/exporters/templates.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+from jinja2.sandbox import SandboxedEnvironment  # type: ignore[import-not-found]
+
+from .helpers import iso8601, join_section_path
+
+env = SandboxedEnvironment(autoescape=False)
+env.policies["json.dumps_kwargs"] = {"sort_keys": False}
+env.globals.update(
+    join_section_path=join_section_path,
+    iso8601=iso8601,
+)
+
+
+def compile_template(template: str):
+    """Compile a Jinja2 template in a sandbox.
+
+    Raises:
+        HTTPException: if the template cannot be parsed.
+    """
+    try:
+        return env.from_string(template)
+    except Exception as exc:  # pragma: no cover - jinja2 error messages vary
+        raise HTTPException(status_code=400, detail=f"invalid template: {exc}") from exc
+
+
+__all__ = ["env", "compile_template"]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,37 @@
+import json
+from datetime import datetime
+
+import pytest
+from fastapi import HTTPException
+
+from exporters.templates import compile_template
+
+fake_chunk = {
+    "content": {"type": "text", "text": "hello"},
+    "source": {"section_path": ["A", "B"]},
+    "metadata": {},
+}
+
+fake_doc = {"doc_id": "d1", "created": datetime(2023, 1, 1)}
+
+
+def test_template_renders_helpers():
+    template = (
+        '{{ {"path": join_section_path(chunk.source), '
+        '"created": iso8601(doc.created), '
+        '"text": chunk.content.text} | tojson }}'
+    )
+    tmpl = compile_template(template)
+    rendered = tmpl.render(chunk=fake_chunk, doc=fake_doc)
+    data = json.loads(rendered)
+    assert data == {
+        "path": "A / B",
+        "created": "2023-01-01T00:00:00",
+        "text": "hello",
+    }
+
+
+def test_invalid_template_raises_400():
+    with pytest.raises(HTTPException) as exc:
+        compile_template("{{ bad ::")
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- implement sandboxed Jinja2 Template DSL with helpers
- wire exporters to compile templates with validation
- add tests for template helpers and error handling

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a0acb88440832bbe88010ecf0e53a0