### PR TITLE
[E5-02] Exporters + manifest

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -61,7 +61,7 @@
 | E4‑03 | LS project config | codex | ☑ Done | [PR](#) |  |
 | E4‑04 | LS webhook → metadata | codex | ☑ Done | [PR](#) |  |
 | E5‑01 | Template DSL (Jinja2) | codex | ☑ Done | [PR](#) |  |
-| E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | PR TBD |  |
+| E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | [PR](#) |  |
 | E5‑03 | RAG preset templates | codex | ☑ Done | PR TBD |  |
 | E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | PR TBD |  |
 | E6‑03 | Curation completeness metric | codex | ☑ Done | PR TBD |  |

--- a/api/main.py
+++ b/api/main.py
@@ -657,6 +657,8 @@ def export_jsonl_endpoint(
     store: ObjectStore = Depends(get_object_store),
 ) -> ExportResponse:
     tax = get_taxonomy(payload.project_id, db=db)
+    if not payload.doc_ids:
+        raise HTTPException(status_code=400, detail="doc_ids required")
     export_id, url = export_jsonl(
         store,
         doc_ids=payload.doc_ids,
@@ -664,6 +666,7 @@ def export_jsonl_endpoint(
         preset=payload.preset,
         taxonomy_version=tax.version,
         expiry=settings.export_signed_url_expiry_seconds,
+        filters=payload.filters,
     )
     return ExportResponse(export_id=export_id, url=url)
 
@@ -675,6 +678,8 @@ def export_csv_endpoint(
     store: ObjectStore = Depends(get_object_store),
 ) -> ExportResponse:
     tax = get_taxonomy(payload.project_id, db=db)
+    if not payload.doc_ids:
+        raise HTTPException(status_code=400, detail="doc_ids required")
     export_id, url = export_csv(
         store,
         doc_ids=payload.doc_ids,
@@ -682,6 +687,7 @@ def export_csv_endpoint(
         preset=payload.preset,
         taxonomy_version=tax.version,
         expiry=settings.export_signed_url_expiry_seconds,
+        filters=payload.filters,
     )
     return ExportResponse(export_id=export_id, url=url)
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -90,9 +90,10 @@ class ProjectSettingsUpdate(BaseModel):
 
 class ExportPayload(BaseModel):
     project_id: str
-    doc_ids: List[str]
+    doc_ids: List[str] | None = None
     template: str | None = None
     preset: str | None = None
+    filters: dict | None = None
 
 
 class ExportResponse(BaseModel):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -40,6 +40,7 @@ def test_rag_jsonl_export(test_app) -> None:
             "project_id": str(PROJECT_ID_1),
             "doc_ids": ["d1", "d2"],
             "preset": "rag",
+            "filters": {"status": "parsed"},
         },
     )
     assert resp.status_code == 200
@@ -54,6 +55,12 @@ def test_rag_jsonl_export(test_app) -> None:
     ]
     manifest = json.loads(store.get_bytes(manifest_key).decode("utf-8"))
     assert manifest["doc_ids"] == ["d1", "d2"]
+    assert manifest["taxonomy_version"] == 1
+    assert manifest["filters"] == {"status": "parsed"}
+    assert manifest["template_hash"]
+    assert manifest["parser_commit"]
+    assert manifest["suggestors_commit"]
+    assert "T" in manifest["created_at"]
     # idempotent
     resp2 = client.post(
         "/export/jsonl",
@@ -61,6 +68,7 @@ def test_rag_jsonl_export(test_app) -> None:
             "project_id": str(PROJECT_ID_1),
             "doc_ids": ["d2", "d1"],
             "preset": "rag",
+            "filters": {"status": "parsed"},
         },
     )
     assert resp2.json()["export_id"] == data["export_id"]


### PR DESCRIPTION
## Summary
- include filters and commits in export manifest and compute idempotent export id
- allow export payload filters and enforce doc_ids
- integration tests for JSONL/CSV exports and manifest fields

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0af0ad5b4832b92a12328a55b0b11