### PR TITLE
[E6-01] Rule suggestors

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -63,7 +63,7 @@
 | E5‑01 | Template DSL (Jinja2) | codex | ☑ Done | [PR](#) |  |
 | E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | [PR](#) |  |
 | E5‑03 | RAG preset templates | codex | ☑ Done | [PR](#) |  |
-| E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | PR TBD |  |
+| E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | [PR](#) |  |
 | E6‑03 | Curation completeness metric | codex | ☑ Done | PR TBD |  |
 | E7‑02 | Audit retrieval API | codex | ☑ Done | PR TBD |  |
 | E7‑03 | Scorecard CLI | codex | ☑ Done | PR TBD |  |

--- a/tests/test_suggestors.py
+++ b/tests/test_suggestors.py
@@ -1,14 +1,39 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from models import Chunk as ChunkModel
+from models import Project
+from tests.conftest import PROJECT_ID_1
+from worker import main as worker_main
 from worker.suggestors import suggest
 
 
-def test_rule_suggestors() -> None:
-    text = "Step 1: start process ERROR in INC-1234 on 2024-01-01"
-    result = suggest(text)
-    step = result["step_id"]["value"]
-    assert isinstance(step, str) and step.startswith("Step 1")
+def _setup_worker(store, SessionLocal) -> None:
+    worker_main.create_client = lambda **kwargs: store.client
+    worker_main.settings.s3_bucket = store.bucket
+    worker_main.SessionLocal = SessionLocal
+
+
+def test_severity_detector() -> None:
+    result = suggest("something ERROR happened")
     assert result["severity"]["value"] == "ERROR"
-    assert result["ticket_id"]["value"] == "INC-1234"
-    assert result["datetime"]["value"] == "2024-01-01"
+
+
+def test_step_id_detector() -> None:
+    result = suggest("Step 2: run task")
+    val = result["step_id"]["value"]
+    assert isinstance(val, str) and val.startswith("Step 2")
+
+
+def test_ticket_id_detector() -> None:
+    result = suggest("Refer to BUG-1234 for details")
+    assert result["ticket_id"]["value"] == "BUG-1234"
+
+
+def test_datetime_detector() -> None:
+    result = suggest("Logged on 2024-01-01T10:00:00")
+    assert result["datetime"]["value"] == "2024-01-01T10:00:00"
 
 
 def test_suggestor_toggle_and_limit() -> None:
@@ -16,3 +41,52 @@ def test_suggestor_toggle_and_limit() -> None:
     assert suggest(text, use_rules_suggestor=False) == {}
     limited = suggest(text, max_suggestions=1)
     assert len(limited) == 1
+
+
+def test_pipeline_populates_suggestions(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    _setup_worker(store, SessionLocal)
+    html = "<html><body>Step 1: start ERROR INC-42 on 2024-01-01</body></html>".encode(
+        "utf-8"
+    )
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("x.html", html, "text/html")},
+    )
+    doc_id = resp.json()["doc_id"]
+    worker_main.parse_document(doc_id)
+    with SessionLocal() as db:
+        chunk = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc_id))
+        assert chunk is not None
+        sug = chunk.meta["suggestions"]
+        assert sug["severity"]["value"] == "ERROR"
+        step_val = sug["step_id"]["value"]
+        assert isinstance(step_val, str) and step_val.startswith("Step 1")
+        assert sug["ticket_id"]["value"] == "INC-42"
+        assert sug["datetime"]["value"] == "2024-01-01"
+
+
+def test_pipeline_respects_project_limit(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    _setup_worker(store, SessionLocal)
+    with SessionLocal() as db:
+        proj = db.get(Project, PROJECT_ID_1)
+        assert proj is not None
+        proj.max_suggestions_per_doc = 2
+        db.commit()
+    html = "<html><body>Step 1: start ERROR INC-42 on 2024-01-01</body></html>".encode(
+        "utf-8"
+    )
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("x.html", html, "text/html")},
+    )
+    doc_id = resp.json()["doc_id"]
+    worker_main.parse_document(doc_id)
+    with SessionLocal() as db:
+        chunk = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc_id))
+        assert chunk is not None
+        sug = chunk.meta["suggestions"]
+        assert set(sug.keys()) == {"severity", "step_id"}

--- a/worker/suggestors/rules.py
+++ b/worker/suggestors/rules.py
@@ -14,11 +14,13 @@ class Suggestion:
     span: str
 
     def to_dict(self) -> Dict[str, str | float]:
-        return asdict(self)
+        data = asdict(self)
+        data.pop("field", None)
+        return data
 
 
 _SEVERITY_RE = re.compile(r"\b(DEBUG|INFO|WARN|ERROR|FATAL)\b")
-_STEP_RE = re.compile(r"\bStep\s?\d+:?")
+_STEP_RE = re.compile(r"^Step\s?\d+:", re.MULTILINE)
 _TICKET_RE = re.compile(r"\b(?:JIRA|BUG|INC)-\d+\b")
 _DATETIME_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2})?\b")
 


### PR DESCRIPTION
## Summary
- add regex-based detectors for severity, step id, ticket id and datetimes
- populate chunk metadata suggestions after parsing, respecting project flags and limits
- test rule suggestors and worker integration

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b3d73e44832b8c430bd01ee5f9e9