### PR TITLE
[E6-02] Accept suggestion

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -64,6 +64,7 @@
 | E5‑02 | JSONL/CSV exporters + manifest | codex | ☑ Done | [PR](#) |  |
 | E5‑03 | RAG preset templates | codex | ☑ Done | [PR](#) |  |
 | E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | [PR](#) |  |
+| E6‑02 | Accept suggestion | codex | ☑ Done | [PR](#) |  |
 | E6‑03 | Curation completeness metric | codex | ☑ Done | PR TBD |  |
 | E7‑02 | Audit retrieval API | codex | ☑ Done | PR TBD |  |
 | E7‑03 | Scorecard CLI | codex | ☑ Done | PR TBD |  |


### PR DESCRIPTION
## Summary
- verify single and bulk suggestion acceptance updates chunk metadata and records audits
- ensure missing suggestions return 404
- document completion in STATUS.md

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b68b3ca8832b8eedbc17ec425749