### PR TITLE
[E6-03] Completeness metric

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -65,7 +65,7 @@
 | E5‑03 | RAG preset templates | codex | ☑ Done | [PR](#) |  |
 | E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | [PR](#) |  |
 | E6‑02 | Accept suggestion | codex | ☑ Done | [PR](#) |  |
-| E6‑03 | Curation completeness metric | codex | ☑ Done | PR TBD |  |
+| E6‑03 | Curation completeness metric | codex | ☑ Done | [PR](#) |  |
 | E7‑02 | Audit retrieval API | codex | ☑ Done | PR TBD |  |
 | E7‑03 | Scorecard CLI | codex | ☑ Done | PR TBD |  |
 | E4‑05 | Bulk metadata apply | codex | ☑ Done | [PR](#) |  |

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -22,6 +22,17 @@ def _required_fields(project_id: uuid.UUID | str, db: Session) -> list[str]:
     return [f["name"] for f in tax.fields if f.get("required")]
 
 
+def _has_value(meta: dict, field: str) -> bool:
+    if field not in meta:
+        return False
+    value = meta[field]
+    if value is None:
+        return False
+    if isinstance(value, str) and value.strip() == "":
+        return False
+    return True
+
+
 def compute_curation_completeness(
     doc_id: uuid.UUID | str,
     project_id: uuid.UUID | str,
@@ -40,7 +51,7 @@ def compute_curation_completeness(
         return 1.0
     complete = 0
     for c in chunk_list:
-        if all(field in c.meta for field in required):
+        if all(_has_value(c.meta, field) for field in required):
             complete += 1
     return complete / total
 

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -1,0 +1,40 @@
+from chunking.chunker import Block, chunk_blocks
+from core.metrics import compute_curation_completeness
+from tests.conftest import PROJECT_ID_1
+from worker.derived_writer import upsert_chunks
+
+
+def test_curation_completeness_metric(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    payload = {
+        "fields": [
+            {
+                "name": "severity",
+                "type": "enum",
+                "required": True,
+                "options": ["low", "high"],
+            }
+        ]
+    }
+    client.put(
+        f"/projects/{PROJECT_ID_1}/taxonomy",
+        json=payload,
+        headers={"X-Role": "curator"},
+    )
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("doc.txt", b"hello", "text/plain")},
+    )
+    doc_id = resp.json()["doc_id"]
+    blocks = [Block(text="a", page=1), Block(text="b", page=1)]
+    chunks = chunk_blocks(blocks, min_tokens=1, max_tokens=1)
+    chunks[0].metadata = {"severity": "high"}
+    chunks[1].metadata = {"severity": ""}
+    with SessionLocal() as db:
+        upsert_chunks(db, store, doc_id=doc_id, version=1, chunks=chunks)
+        comp = compute_curation_completeness(doc_id, PROJECT_ID_1, 1, db)
+    assert comp == 0.5
+    resp_metrics = client.get(f"/documents/{doc_id}/metrics")
+    assert resp_metrics.status_code == 200
+    assert resp_metrics.json()["curation_completeness"] == 0.5


### PR DESCRIPTION
## Summary
- ensure curation completeness only counts chunks whose required metadata fields are non-empty
- expose document-level curation completeness via metrics endpoint
- add unit test covering completeness calculation and API response

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a0b958e774832b8260006df5f6c486