### PR TITLE
[E6-04] Quality gates

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -26,7 +26,7 @@
 | Milestone | Definition of Done | Status |
 |---|---|---|
 | Walking skeleton | ingest→parse→LS tag→export works on golden set | ☐ |
-| Quality gates set | parse metrics + curation completeness enforced | ☐ |
+| Quality gates set | parse metrics + curation completeness enforced | ☑ |
 | RAG preset export | context+answer JSONL available | ☑ |
 | Audit + RBAC | viewer/curator enforced; audit API live | ☑ |
 | CI green | lint/test/scorecard green on main | ☑ |
@@ -66,6 +66,7 @@
 | E6‑01 | Rule‑based suggestors v1 | codex | ☑ Done | [PR](#) |  |
 | E6‑02 | Accept suggestion | codex | ☑ Done | [PR](#) |  |
 | E6‑03 | Curation completeness metric | codex | ☑ Done | [PR](#) |  |
+| E6‑04 | Quality gates | codex | ☑ Done | [PR](#) |  |
 | E7‑02 | Audit retrieval API | codex | ☑ Done | PR TBD |  |
 | E7‑03 | Scorecard CLI | codex | ☑ Done | PR TBD |  |
 | E4‑05 | Bulk metadata apply | codex | ☑ Done | [PR](#) |  |

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -6,11 +6,14 @@ from typing import Iterable
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from chunking.chunker import Chunk as ParsedChunk
 from core.settings import get_settings
 from models import Chunk, DocumentStatus, DocumentVersion, Taxonomy
 
 
 def _required_fields(project_id: uuid.UUID | str, db: Session) -> list[str]:
+    if isinstance(project_id, str):
+        project_id = uuid.UUID(project_id)
     tax = db.scalar(
         select(Taxonomy)
         .where(Taxonomy.project_id == project_id)
@@ -56,6 +59,32 @@ def compute_curation_completeness(
     return complete / total
 
 
+def compute_parse_metrics(
+    chunks: Iterable[ParsedChunk],
+    *,
+    mime: str,
+) -> dict[str, float]:
+    chunk_list = list(chunks)
+    total = len(chunk_list)
+    if total == 0:
+        return {
+            "empty_chunk_ratio": 0.0,
+            "html_section_path_coverage": 0.0,
+        }
+    empty = 0
+    with_section = 0
+    for ch in chunk_list:
+        text = ch.content.text if ch.content.type == "text" else None
+        if text is None or text.strip() == "":
+            empty += 1
+        if ch.source.section_path:
+            with_section += 1
+    return {
+        "empty_chunk_ratio": empty / total,
+        "html_section_path_coverage": with_section / total,
+    }
+
+
 def enforce_quality_gates(
     doc_id: uuid.UUID | str,
     project_id: uuid.UUID | str,
@@ -71,13 +100,24 @@ def enforce_quality_gates(
     )
     if dv is None:
         return
-    completeness = compute_curation_completeness(doc_id, project_id, version, db)
     metrics = dict(dv.meta.get("metrics", {}))
+    completeness = compute_curation_completeness(doc_id, project_id, version, db)
     metrics["curation_completeness"] = completeness
     dv.meta = {**dv.meta, "metrics": metrics}
+
+    breach = False
+    empty_ratio = metrics.get("empty_chunk_ratio")
+    if empty_ratio is not None and empty_ratio > settings.empty_chunk_ratio_threshold:
+        breach = True
+    section_cov = metrics.get("html_section_path_coverage")
+    if dv.mime == "text/html" and (
+        section_cov is None
+        or section_cov < settings.html_section_path_coverage_threshold
+    ):
+        breach = True
+    if completeness < settings.curation_completeness_threshold:
+        breach = True
     dv.status = (
-        DocumentStatus.NEEDS_REVIEW.value
-        if completeness < settings.curation_completeness_threshold
-        else DocumentStatus.PARSED.value
+        DocumentStatus.NEEDS_REVIEW.value if breach else DocumentStatus.PARSED.value
     )
     db.add(dv)

--- a/core/settings.py
+++ b/core/settings.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     s3_bucket: str
     export_signed_url_expiry_seconds: int = 600
     curation_completeness_threshold: float = 0.8
+    empty_chunk_ratio_threshold: float = 0.1
+    html_section_path_coverage_threshold: float = 0.9
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -1,0 +1,82 @@
+import worker.main as worker_main
+from models import Chunk, DocumentStatus, DocumentVersion
+from tests.conftest import PROJECT_ID_1
+
+
+def test_quality_gates_parse_metrics(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    html = b"<html><body><table></table><p>text</p></body></html>"
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("doc.html", html, "text/html")},
+    )
+    doc_id = resp.json()["doc_id"]
+    orig_session = worker_main.SessionLocal
+    orig_store = worker_main._get_store
+    worker_main.SessionLocal = SessionLocal  # type: ignore[assignment]
+    worker_main._get_store = lambda: store  # type: ignore[assignment]
+    try:
+        worker_main.parse_document(doc_id)
+    finally:
+        worker_main.SessionLocal = orig_session  # type: ignore[assignment]
+        worker_main._get_store = orig_store  # type: ignore[assignment]
+    with SessionLocal() as db:
+        dv = db.query(DocumentVersion).filter_by(document_id=doc_id, version=1).one()
+        metrics = dv.meta["metrics"]
+        assert dv.status == DocumentStatus.NEEDS_REVIEW.value
+        assert metrics["empty_chunk_ratio"] > 0.1
+        assert metrics["html_section_path_coverage"] < 0.9
+
+
+def test_quality_gates_after_metadata_change(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    payload = {
+        "fields": [
+            {
+                "name": "severity",
+                "type": "enum",
+                "required": True,
+                "options": ["low", "high"],
+            }
+        ]
+    }
+    client.put(
+        f"/projects/{PROJECT_ID_1}/taxonomy",
+        json=payload,
+        headers={"X-Role": "curator"},
+    )
+    html = b"<html><body><h1>Title</h1><p>text</p></body></html>"
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("doc.html", html, "text/html")},
+    )
+    doc_id = resp.json()["doc_id"]
+    orig_session = worker_main.SessionLocal
+    orig_store = worker_main._get_store
+    worker_main.SessionLocal = SessionLocal  # type: ignore[assignment]
+    worker_main._get_store = lambda: store  # type: ignore[assignment]
+    try:
+        worker_main.parse_document(doc_id)
+    finally:
+        worker_main.SessionLocal = orig_session  # type: ignore[assignment]
+        worker_main._get_store = orig_store  # type: ignore[assignment]
+    with SessionLocal() as db:
+        dv = db.query(DocumentVersion).filter_by(document_id=doc_id, version=1).one()
+        assert dv.status == DocumentStatus.NEEDS_REVIEW.value
+        chunk = db.query(Chunk).filter_by(document_id=doc_id, version=1).first()
+        chunk_id = chunk.id
+    client.post(
+        "/chunks/bulk-apply",
+        json={
+            "selection": {"chunk_ids": [chunk_id]},
+            "patch": {"metadata": {"severity": "low"}},
+            "user": "u1",
+        },
+        headers={"X-Role": "curator"},
+    )
+    with SessionLocal() as db:
+        dv = db.query(DocumentVersion).filter_by(document_id=doc_id, version=1).one()
+        assert dv.status == DocumentStatus.PARSED.value
+        assert dv.meta["metrics"]["curation_completeness"] == 1.0


### PR DESCRIPTION
## Summary
- enforce empty chunk, section path coverage, and curation completeness gates
- record parse metrics and apply gates on parse and metadata updates
- add tests for quality gate pass/fail scenarios

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0bafb3200832b937e5a5397ea5fa1