### PR TITLE
[E7-01] Correlation IDs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -67,6 +67,7 @@
 | E6‑02 | Accept suggestion | codex | ☑ Done | [PR](#) |  |
 | E6‑03 | Curation completeness metric | codex | ☑ Done | [PR](#) |  |
 | E6‑04 | Quality gates | codex | ☑ Done | [PR](#) |  |
+| E7‑01 | Correlation IDs | codex | ☑ Done | [PR](#) |  |
 | E7‑02 | Audit retrieval API | codex | ☑ Done | PR TBD |  |
 | E7‑03 | Scorecard CLI | codex | ☑ Done | PR TBD |  |
 | E4‑05 | Bulk metadata apply | codex | ☑ Done | [PR](#) |  |

--- a/api/main.py
+++ b/api/main.py
@@ -38,6 +38,7 @@ from api.schemas import (
     WebhookPayload,
 )
 from core.correlation import get_request_id, new_request_id, set_request_id
+from core.logging import configure_logging
 from core.metrics import compute_curation_completeness, enforce_quality_gates
 from core.settings import get_settings
 from exporters import export_csv, export_jsonl
@@ -60,6 +61,7 @@ engine = sa.create_engine(settings.database_url)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 app = FastAPI()
+configure_logging()
 
 
 @app.middleware("http")

--- a/core/logging.py
+++ b/core/logging.py
@@ -1,0 +1,30 @@
+import json
+import logging
+from typing import Any
+
+from core.correlation import get_request_id
+
+
+class RequestIDFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        record.request_id = get_request_id()
+        return True
+
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        log: dict[str, Any] = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", None),
+        }
+        return json.dumps(log)
+
+
+def configure_logging() -> None:
+    handler = logging.StreamHandler()
+    handler.addFilter(RequestIDFilter())
+    handler.setFormatter(JSONFormatter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,9 +54,16 @@ class FakeS3Client:
 
 
 @pytest.fixture
-def test_app() -> (
-    Generator[tuple[TestClient, ObjectStore, List[str], sessionmaker], None, None]
-):
+def test_app() -> Generator[
+    tuple[
+        TestClient,
+        ObjectStore,
+        List[Tuple[str, str | None]],
+        sessionmaker,
+    ],
+    None,
+    None,
+]:
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -83,12 +90,12 @@ def test_app() -> (
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_object_store] = lambda: store
 
-    calls: List[str] = []
+    calls: List[Tuple[str, str | None]] = []
 
     from worker import main as worker_main
 
     def fake_delay(doc_id: str, request_id: str | None = None) -> None:
-        calls.append(doc_id)
+        calls.append((doc_id, request_id))
 
     worker_main.parse_document.delay = fake_delay
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -10,7 +10,7 @@ def test_deduplication(test_app) -> None:
     )
     assert resp.status_code == 200
     doc_id = resp.json()["doc_id"]
-    assert calls == [doc_id]
+    assert [c[0] for c in calls] == [doc_id]
     assert len(store.client.store) == 1
 
     resp2 = client.post(
@@ -21,4 +21,4 @@ def test_deduplication(test_app) -> None:
     assert resp2.status_code == 200
     assert resp2.json()["doc_id"] == doc_id
     assert len(store.client.store) == 1
-    assert calls == [doc_id]
+    assert [c[0] for c in calls] == [doc_id]

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,0 +1,25 @@
+import logging
+
+from core.correlation import set_request_id
+from tests.conftest import PROJECT_ID_1
+from worker import main as worker_main
+
+
+def test_request_id_propagates_to_celery(test_app) -> None:
+    client, _, calls, _ = test_app
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("doc.txt", b"hello", "text/plain")},
+        headers={"X-Request-ID": "rid-123"},
+    )
+    assert resp.status_code == 200
+    doc_id = resp.json()["doc_id"]
+    assert calls == [(doc_id, "rid-123")]
+
+
+def test_worker_logs_include_request_id(caplog) -> None:
+    set_request_id("rid-log")
+    with caplog.at_level(logging.INFO):
+        worker_main.logger.info("hello")
+    assert any(record.request_id == "rid-log" for record in caplog.records)

--- a/worker/main.py
+++ b/worker/main.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 
 from chunking.chunker import chunk_blocks
 from core.correlation import set_request_id
+from core.logging import configure_logging
 from core.metrics import compute_parse_metrics, enforce_quality_gates
 from core.settings import get_settings
 from models import Document, DocumentStatus
@@ -21,6 +22,8 @@ settings = get_settings()
 app = Celery("worker", broker=settings.redis_url)
 engine = sa.create_engine(settings.database_url)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+configure_logging()
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- add JSON logging with request IDs
- propagate request IDs through middleware and Celery
- test request ID propagation across API and worker logs

## Testing
- `make lint`
- `make test`
- `pytest tests/test_request_id.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a0be0d00a0832b999050a73dc7823c