### PR TITLE
[E9-01] JWT RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 ## Curation API
 
 Phase‑1 exposes endpoints for managing a per‑project taxonomy and for applying
-curation metadata to chunks. Endpoints require an `X-Role` header; only
-`curator` may modify data while `viewer` can read.
+curation metadata to chunks. Endpoints require an `Authorization: Bearer <jwt>`
+header with a `role` claim. In `ENV=DEV`, you may override the role using
+`X-Role`. Only `curator` may modify data while `viewer` can read.
 
 * `POST /projects` – create a new project and return its `id`.
 * `PUT /projects/{project_id}/taxonomy` – create a new taxonomy version with

--- a/STATUS.md
+++ b/STATUS.md
@@ -71,7 +71,7 @@
 | E7‑02 | Audit retrieval API | codex | ☑ Done | [PR](#) |  |
 | E7‑03 | Scorecard CLI | codex | ☑ Done | [PR](#) |  |
 | E4‑05 | Bulk metadata apply | codex | ☑ Done | [PR](#) |  |
-| E9‑01 | RBAC (viewer/curator) | codex | ☑ Done | PR TBD |  |
+| E9‑01 | RBAC (viewer/curator) | codex | ☑ Done | [PR](#) |  |
 | E9‑02 | Project settings: engine toggles & cost guards | codex | ☑ Done | PR TBD |  |
 | E9‑03 | Signed URL policy | codex | ☑ Done | PR TBD |  |
 | E9-04 | Project onboarding API | codex | ☑ Done | PR TBD |  |

--- a/api/deps.py
+++ b/api/deps.py
@@ -1,0 +1,13 @@
+from fastapi import Depends, HTTPException
+
+from core.auth import get_current_role
+
+
+def require_viewer(role: str = Depends(get_current_role)) -> str:
+    return role
+
+
+def require_curator(role: str = Depends(get_current_role)) -> str:
+    if role != "curator":
+        raise HTTPException(status_code=403, detail="forbidden")
+    return role

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,0 +1,24 @@
+import jwt
+from fastapi import Header, HTTPException
+
+from core.settings import get_settings
+
+
+def get_current_role(
+    authorization: str | None = Header(default=None),
+    x_role: str | None = Header(default=None),
+) -> str:
+    settings = get_settings()
+    if settings.env == "DEV" and x_role:
+        return x_role
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=403, detail="forbidden")
+    token = authorization.split(" ", 1)[1]
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=["HS256"])
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=403, detail="forbidden")
+    role = payload.get("role")
+    if role not in {"viewer", "curator"}:
+        raise HTTPException(status_code=403, detail="forbidden")
+    return role

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,7 +1,29 @@
-import jwt
+import base64
+import hashlib
+import hmac
+import json
+
 from fastapi import Header, HTTPException
 
 from core.settings import get_settings
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _decode_jwt(token: str, secret: str) -> dict:
+    header_b64, payload_b64, signature_b64 = token.split(".")
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    expected = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    actual = _b64url_decode(signature_b64)
+    if not hmac.compare_digest(expected, actual):
+        raise ValueError("invalid signature")
+    header = json.loads(_b64url_decode(header_b64).decode())
+    if header.get("alg") != "HS256":
+        raise ValueError("unsupported alg")
+    return json.loads(_b64url_decode(payload_b64).decode())
 
 
 def get_current_role(
@@ -15,8 +37,8 @@ def get_current_role(
         raise HTTPException(status_code=403, detail="forbidden")
     token = authorization.split(" ", 1)[1]
     try:
-        payload = jwt.decode(token, settings.jwt_secret, algorithms=["HS256"])
-    except jwt.PyJWTError:
+        payload = _decode_jwt(token, settings.jwt_secret)
+    except Exception:
         raise HTTPException(status_code=403, detail="forbidden")
     role = payload.get("role")
     if role not in {"viewer", "curator"}:

--- a/core/settings.py
+++ b/core/settings.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     curation_completeness_threshold: float = 0.8
     empty_chunk_ratio_threshold: float = 0.1
     html_section_path_coverage_threshold: float = 0.9
+    jwt_secret: str = "change-me"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "redis",
     "python-multipart",
     "httpx",
-    "psycopg2-binary"
+    "psycopg2-binary",
+    "PyJWT"
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ dependencies = [
     "redis",
     "python-multipart",
     "httpx",
-    "psycopg2-binary",
-    "PyJWT"
+    "psycopg2-binary"
 ]
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ PyMuPDF
 beautifulsoup4
 jinja2
 psycopg2-binary
-PyJWT

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyMuPDF
 beautifulsoup4
 jinja2
 psycopg2-binary
+PyJWT

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,42 @@
+import jwt
+
+from core.settings import get_settings
+from tests.conftest import PROJECT_ID_1
+
+
+def make_token(role: str) -> str:
+    secret = get_settings().jwt_secret
+    return jwt.encode({"role": role}, secret, algorithm="HS256")
+
+
+def test_curator_required_for_project_settings(test_app):
+    client, _, _, _ = test_app
+    url = f"/projects/{PROJECT_ID_1}/settings"
+    body = {"use_rules_suggestor": True}
+
+    r = client.patch(url, json=body)
+    assert r.status_code == 403
+
+    viewer = {"Authorization": f"Bearer {make_token('viewer')}"}
+    r2 = client.patch(url, json=body, headers=viewer)
+    assert r2.status_code == 403
+
+    curator = {"Authorization": f"Bearer {make_token('curator')}"}
+    r3 = client.patch(url, json=body, headers=curator)
+    assert r3.status_code == 200
+
+
+def test_export_requires_curator(test_app):
+    client, _, _, _ = test_app
+    payload = {
+        "project_id": str(PROJECT_ID_1),
+        "doc_ids": ["d1"],
+        "template": "{{}}",
+    }
+
+    r = client.post("/export/jsonl", json=payload)
+    assert r.status_code == 403
+
+    viewer = {"Authorization": f"Bearer {make_token('viewer')}"}
+    r2 = client.post("/export/jsonl", json=payload, headers=viewer)
+    assert r2.status_code == 403

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -42,6 +42,7 @@ def test_csv_export_custom_template(test_app) -> None:
             "doc_ids": ["d1", "d2"],
             "template": template,
         },
+        headers={"X-Role": "curator"},
     )
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/test_rag_preset.py
+++ b/tests/test_rag_preset.py
@@ -41,6 +41,7 @@ def test_rag_jsonl_export(test_app) -> None:
             "doc_ids": ["d1", "d2"],
             "preset": "rag",
         },
+        headers={"X-Role": "curator"},
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -64,6 +65,7 @@ def test_rag_csv_export(test_app) -> None:
             "doc_ids": ["d1", "d2"],
             "preset": "rag",
         },
+        headers={"X-Role": "curator"},
     )
     assert resp.status_code == 200
     data = resp.json()


### PR DESCRIPTION
## Summary
- add HS256 JWT auth with role claim and dev X-Role override
- provide require_viewer/require_curator dependencies and secure exports
- document JWT usage and add tests for role enforcement

## Testing
- `make lint` *(fails: Missing module 'jwt')*
- `make test` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68a0c8e4de18832bb92eb91955219052