### PR TITLE
[E9-02] Signed URLs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -72,8 +72,7 @@
 | E7‑03 | Scorecard CLI | codex | ☑ Done | [PR](#) |  |
 | E4‑05 | Bulk metadata apply | codex | ☑ Done | [PR](#) |  |
 | E9‑01 | RBAC (viewer/curator) | codex | ☑ Done | [PR](#) |  |
-| E9‑02 | Project settings: engine toggles & cost guards | codex | ☑ Done | PR TBD |  |
-| E9‑03 | Signed URL policy | codex | ☑ Done | PR TBD |  |
+| E9‑02 | Signed URL policy | codex | ☑ Done | [PR](#) |  |
 | E9-04 | Project onboarding API | codex | ☑ Done | PR TBD |  |
 | E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
 

--- a/api/main.py
+++ b/api/main.py
@@ -672,7 +672,6 @@ def export_jsonl_endpoint(
         template=payload.template,
         preset=payload.preset,
         taxonomy_version=tax.version,
-        expiry=settings.export_signed_url_expiry_seconds,
         filters=payload.filters,
     )
     return ExportResponse(export_id=export_id, url=url)
@@ -694,7 +693,6 @@ def export_csv_endpoint(
         template=payload.template,
         preset=payload.preset,
         taxonomy_version=tax.version,
-        expiry=settings.export_signed_url_expiry_seconds,
         filters=payload.filters,
     )
     return ExportResponse(export_id=export_id, url=url)

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -6,7 +6,7 @@ import subprocess
 from datetime import datetime
 from typing import Dict, Iterable, List, Tuple
 
-from storage.object_store import ObjectStore, derived_key, export_key
+from storage.object_store import ObjectStore, derived_key, export_key, signed_url
 
 from .presets import RAG_TEMPLATE, get_preset
 from .templates import compile_template
@@ -99,7 +99,6 @@ def export_jsonl(
     template: str | None,
     preset: str | None,
     taxonomy_version: int,
-    expiry: int,
     filters: Dict | None,
 ) -> Tuple[str, str]:
     template_str = _get_template(template, preset)
@@ -111,7 +110,7 @@ def export_jsonl(
     manifest_key = export_key(export_id, "manifest.json")
     try:
         store.get_bytes(manifest_key)
-        url = store.presign_get(data_key, expiry)
+        url = signed_url(store, data_key)
         return export_id, url
     except Exception:
         pass
@@ -125,7 +124,7 @@ def export_jsonl(
         template_hash,
         filters,
     )
-    url = store.presign_get(data_key, expiry)
+    url = signed_url(store, data_key)
     return export_id, url
 
 
@@ -136,7 +135,6 @@ def export_csv(
     template: str | None,
     preset: str | None,
     taxonomy_version: int,
-    expiry: int,
     filters: Dict | None,
 ) -> Tuple[str, str]:
     template_str = _get_template(template, preset)
@@ -148,7 +146,7 @@ def export_csv(
     manifest_key = export_key(export_id, "manifest.json")
     try:
         store.get_bytes(manifest_key)
-        url = store.presign_get(data_key, expiry)
+        url = signed_url(store, data_key)
         return export_id, url
     except Exception:
         pass
@@ -170,7 +168,7 @@ def export_csv(
         template_hash,
         filters,
     )
-    url = store.presign_get(data_key, expiry)
+    url = signed_url(store, data_key)
     return export_id, url
 
 

--- a/storage/object_store.py
+++ b/storage/object_store.py
@@ -4,6 +4,8 @@ from typing import List
 import boto3  # type: ignore[import-untyped]
 from botocore.client import BaseClient  # type: ignore[import-untyped]
 
+from core.settings import get_settings
+
 RAW_PREFIX = "raw"
 DERIVED_PREFIX = "derived"
 EXPORTS_PREFIX = "exports"
@@ -60,10 +62,18 @@ class ObjectStore:
         )
 
 
+def signed_url(store: "ObjectStore", key: str, expiry: int | None = None) -> str:
+    """Generate a presigned GET URL using settings for expiry."""
+    settings = get_settings()
+    exp = expiry or settings.export_signed_url_expiry_seconds
+    return store.presign_get(key, exp)
+
+
 __all__ = [
     "ObjectStore",
     "create_client",
     "raw_key",
     "derived_key",
     "export_key",
+    "signed_url",
 ]

--- a/tests/test_signed_urls.py
+++ b/tests/test_signed_urls.py
@@ -1,0 +1,49 @@
+import json
+from typing import List
+
+from models import Taxonomy
+from storage.object_store import derived_key, export_key
+from tests.conftest import PROJECT_ID_1
+
+
+def _add_taxonomy(SessionLocal) -> None:
+    with SessionLocal() as session:
+        session.add(Taxonomy(project_id=PROJECT_ID_1, version=1, fields=[]))
+        session.commit()
+
+
+def _put_chunk(store, doc_id: str, text: str, section: List[str]) -> None:
+    chunk = {
+        "doc_id": doc_id,
+        "chunk_id": f"{doc_id}-c1",
+        "order": 0,
+        "rev": 1,
+        "content": {"type": "text", "text": text},
+        "source": {"page": 1, "section_path": section},
+        "text_hash": "h",
+        "metadata": {},
+    }
+    store.put_bytes(
+        derived_key(doc_id, "chunks.jsonl"),
+        (json.dumps(chunk) + "\n").encode("utf-8"),
+    )
+
+
+def test_export_returns_presigned_url(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    _add_taxonomy(SessionLocal)
+    _put_chunk(store, "d1", "alpha", ["A"])
+    resp = client.post(
+        "/export/jsonl",
+        json={
+            "project_id": str(PROJECT_ID_1),
+            "doc_ids": ["d1"],
+            "template": "{{ chunk.content.text }}",
+        },
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    key = export_key(data["export_id"], "data.jsonl")
+    assert "X-Amz-Expires" in data["url"]
+    assert not data["url"].startswith(key)


### PR DESCRIPTION
## Summary
- centralize presigned GET generation with expiry from settings
- ensure JSONL/CSV exporters and API use signed URLs exclusively
- verify responses never expose raw bucket paths

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e166d6dc832ba357cfe31da87ac3