### PR TITLE
[E9-03] Project settings wiring

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -73,6 +73,7 @@
 | E4‑05 | Bulk metadata apply | codex | ☑ Done | [PR](#) |  |
 | E9‑01 | RBAC (viewer/curator) | codex | ☑ Done | [PR](#) |  |
 | E9‑02 | Signed URL policy | codex | ☑ Done | [PR](#) |  |
+| E9-03 | Project settings wiring | codex | ☑ Done | [PR](#) |  |
 | E9-04 | Project onboarding API | codex | ☑ Done | PR TBD |  |
 | E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
 

--- a/api/main.py
+++ b/api/main.py
@@ -664,6 +664,13 @@ def export_jsonl_endpoint(
     _: str = Depends(require_curator),
 ) -> ExportResponse:
     tax = get_taxonomy(payload.project_id, db=db)
+    try:
+        proj_uuid = uuid.UUID(payload.project_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid project_id")
+    project = db.get(Project, proj_uuid)
+    if project is None:
+        raise HTTPException(status_code=404, detail="project not found")
     if not payload.doc_ids:
         raise HTTPException(status_code=400, detail="doc_ids required")
     export_id, url = export_jsonl(
@@ -673,6 +680,7 @@ def export_jsonl_endpoint(
         preset=payload.preset,
         taxonomy_version=tax.version,
         filters=payload.filters,
+        project=project,
     )
     return ExportResponse(export_id=export_id, url=url)
 
@@ -685,6 +693,13 @@ def export_csv_endpoint(
     _: str = Depends(require_curator),
 ) -> ExportResponse:
     tax = get_taxonomy(payload.project_id, db=db)
+    try:
+        proj_uuid = uuid.UUID(payload.project_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid project_id")
+    project = db.get(Project, proj_uuid)
+    if project is None:
+        raise HTTPException(status_code=404, detail="project not found")
     if not payload.doc_ids:
         raise HTTPException(status_code=400, detail="doc_ids required")
     export_id, url = export_csv(
@@ -694,6 +709,7 @@ def export_csv_endpoint(
         preset=payload.preset,
         taxonomy_version=tax.version,
         filters=payload.filters,
+        project=project,
     )
     return ExportResponse(export_id=export_id, url=url)
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -14,6 +14,8 @@ class Settings(BaseSettings):
     minio_secure: bool = False
     s3_bucket: str
     export_signed_url_expiry_seconds: int = 600
+    suggestion_timeout_ms: int = 500
+    max_suggestions_per_doc: int = 200
     curation_completeness_threshold: float = 0.8
     empty_chunk_ratio_threshold: float = 0.1
     html_section_path_coverage_threshold: float = 0.9

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -4,7 +4,7 @@ import io
 import json
 import subprocess
 from datetime import datetime
-from typing import Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 from storage.object_store import ObjectStore, derived_key, export_key, signed_url
 
@@ -20,7 +20,10 @@ def _get_template(template: str | None, preset: str | None) -> str:
     return template
 
 
-def _load_chunks(store: ObjectStore, doc_ids: List[str]) -> Iterable[dict]:
+def _load_chunks(
+    store: ObjectStore, doc_ids: List[str], project: Any | None = None
+) -> Iterable[dict]:
+    counts: Dict[str, int] = {doc_id: 0 for doc_id in doc_ids}
     for doc_id in doc_ids:
         data = (
             store.get_bytes(derived_key(doc_id, "chunks.jsonl")).decode("utf-8").strip()
@@ -28,7 +31,25 @@ def _load_chunks(store: ObjectStore, doc_ids: List[str]) -> Iterable[dict]:
         if not data:
             continue
         for line in data.splitlines():
-            yield json.loads(line)
+            ch = json.loads(line)
+            if project:
+                meta = ch.get("metadata", {})
+                sugg = meta.get("suggestions")
+                if sugg:
+                    if not (project.use_rules_suggestor or project.use_mini_llm):
+                        meta.pop("suggestions", None)
+                    else:
+                        remaining = project.max_suggestions_per_doc - counts[doc_id]
+                        if remaining <= 0:
+                            meta.pop("suggestions", None)
+                        else:
+                            if len(sugg) > remaining:
+                                keys = list(sugg.keys())[:remaining]
+                                meta["suggestions"] = {k: sugg[k] for k in keys}
+                                counts[doc_id] += len(keys)
+                            else:
+                                counts[doc_id] += len(sugg)
+            yield ch
 
 
 def _compute_export_id(
@@ -37,19 +58,25 @@ def _compute_export_id(
     taxonomy_version: int,
     template_str: str,
     filters: Dict | None,
+    project: Any | None,
 ) -> Tuple[str, str, List[str]]:
     doc_ids_sorted = sorted(doc_ids)
     template_hash = hashlib.sha256(template_str.encode("utf-8")).hexdigest()
-    payload = json.dumps(
-        {
-            "format": fmt,
-            "doc_ids": doc_ids_sorted,
-            "taxonomy_version": taxonomy_version,
-            "template_hash": template_hash,
-            "filters": filters or {},
-        },
-        sort_keys=True,
-    )
+    payload_dict: Dict[str, Any] = {
+        "format": fmt,
+        "doc_ids": doc_ids_sorted,
+        "taxonomy_version": taxonomy_version,
+        "template_hash": template_hash,
+        "filters": filters or {},
+    }
+    if project:
+        payload_dict["project_settings"] = {
+            "use_rules_suggestor": project.use_rules_suggestor,
+            "use_mini_llm": project.use_mini_llm,
+            "max_suggestions_per_doc": project.max_suggestions_per_doc,
+            "suggestion_timeout_ms": project.suggestion_timeout_ms,
+        }
+    payload = json.dumps(payload_dict, sort_keys=True)
     return (
         hashlib.sha256(payload.encode("utf-8")).hexdigest(),
         template_hash,
@@ -78,6 +105,7 @@ def _write_manifest(
     taxonomy_version: int,
     template_hash: str,
     filters: Dict | None,
+    project: Any | None,
 ) -> None:
     manifest_key = export_key(export_id, "manifest.json")
     manifest = {
@@ -87,6 +115,16 @@ def _write_manifest(
         "filters": filters or {},
         "parser_commit": _parser_commit(),
         "suggestors_commit": _suggestors_commit(),
+        "project_settings": (
+            {
+                "use_rules_suggestor": project.use_rules_suggestor,
+                "use_mini_llm": project.use_mini_llm,
+                "max_suggestions_per_doc": project.max_suggestions_per_doc,
+                "suggestion_timeout_ms": project.suggestion_timeout_ms,
+            }
+            if project
+            else {}
+        ),
         "created_at": datetime.utcnow().isoformat(),
     }
     store.put_bytes(manifest_key, json.dumps(manifest, sort_keys=True).encode("utf-8"))
@@ -100,11 +138,12 @@ def export_jsonl(
     preset: str | None,
     taxonomy_version: int,
     filters: Dict | None,
+    project: Any | None = None,
 ) -> Tuple[str, str]:
     template_str = _get_template(template, preset)
     tmpl = compile_template(template_str)
     export_id, template_hash, doc_ids_sorted = _compute_export_id(
-        "jsonl", doc_ids, taxonomy_version, template_str, filters
+        "jsonl", doc_ids, taxonomy_version, template_str, filters, project
     )
     data_key = export_key(export_id, "data.jsonl")
     manifest_key = export_key(export_id, "manifest.json")
@@ -114,7 +153,9 @@ def export_jsonl(
         return export_id, url
     except Exception:
         pass
-    lines = [tmpl.render(chunk=ch) for ch in _load_chunks(store, doc_ids_sorted)]
+    lines = [
+        tmpl.render(chunk=ch) for ch in _load_chunks(store, doc_ids_sorted, project)
+    ]
     store.put_bytes(data_key, ("\n".join(lines) + "\n").encode("utf-8"))
     _write_manifest(
         store,
@@ -123,6 +164,7 @@ def export_jsonl(
         taxonomy_version,
         template_hash,
         filters,
+        project,
     )
     url = signed_url(store, data_key)
     return export_id, url
@@ -136,11 +178,12 @@ def export_csv(
     preset: str | None,
     taxonomy_version: int,
     filters: Dict | None,
+    project: Any | None = None,
 ) -> Tuple[str, str]:
     template_str = _get_template(template, preset)
     tmpl = compile_template(template_str)
     export_id, template_hash, doc_ids_sorted = _compute_export_id(
-        "csv", doc_ids, taxonomy_version, template_str, filters
+        "csv", doc_ids, taxonomy_version, template_str, filters, project
     )
     data_key = export_key(export_id, "data.csv")
     manifest_key = export_key(export_id, "manifest.json")
@@ -151,7 +194,8 @@ def export_csv(
     except Exception:
         pass
     rows = [
-        json.loads(tmpl.render(chunk=ch)) for ch in _load_chunks(store, doc_ids_sorted)
+        json.loads(tmpl.render(chunk=ch))
+        for ch in _load_chunks(store, doc_ids_sorted, project)
     ]
     headers = sorted(rows[0].keys()) if rows else []
     buf = io.StringIO()
@@ -167,6 +211,7 @@ def export_csv(
         taxonomy_version,
         template_hash,
         filters,
+        project,
     )
     url = signed_url(store, data_key)
     return export_id, url

--- a/tests/test_project_settings.py
+++ b/tests/test_project_settings.py
@@ -1,4 +1,12 @@
+import json
+
+import sqlalchemy as sa
+
+from models import Chunk as ChunkModel
+from models import Project, Taxonomy
+from storage.object_store import derived_key, export_key
 from tests.conftest import PROJECT_ID_1
+from worker import main as worker_main
 
 
 def test_project_settings_update_and_rbac(test_app) -> None:
@@ -32,3 +40,112 @@ def test_project_settings_update_and_rbac(test_app) -> None:
     # confirm persisted
     resp2 = client.get(f"/projects/{pid}/settings")
     assert resp2.json()["use_rules_suggestor"] is False
+
+
+def _setup_worker(store, SessionLocal) -> None:
+    worker_main.create_client = lambda **kwargs: store.client
+    worker_main.settings.s3_bucket = store.bucket
+    worker_main.SessionLocal = SessionLocal
+
+
+def _add_taxonomy(SessionLocal) -> None:
+    with SessionLocal() as session:
+        session.add(Taxonomy(project_id=PROJECT_ID_1, version=1, fields=[]))
+        session.commit()
+
+
+def _put_chunk(store, doc_id: str) -> None:
+    chunk = {
+        "doc_id": doc_id,
+        "chunk_id": f"{doc_id}-c1",
+        "order": 0,
+        "rev": 1,
+        "content": {"type": "text", "text": "Step 1: start ERROR INC-42 on 2024-01-01"},
+        "source": {"page": 1, "section_path": ["A"]},
+        "text_hash": "h",
+        "metadata": {
+            "suggestions": {
+                "severity": {"value": "ERROR"},
+                "step_id": {"value": "Step 1"},
+            }
+        },
+    }
+    store.put_bytes(
+        derived_key(doc_id, "chunks.jsonl"),
+        (json.dumps(chunk) + "\n").encode("utf-8"),
+    )
+
+
+def test_worker_respects_settings_toggle(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    _setup_worker(store, SessionLocal)
+    pid = str(PROJECT_ID_1)
+
+    html = "<html><body>Step 1: start ERROR INC-42 on 2024-01-01</body></html>".encode(
+        "utf-8"
+    )
+
+    resp1 = client.post(
+        "/ingest",
+        data={"project_id": pid},
+        files={"file": ("a.html", html, "text/html")},
+    )
+    doc1 = resp1.json()["doc_id"]
+    worker_main.parse_document(doc1)
+    with SessionLocal() as db:
+        chunk1 = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc1))
+        assert chunk1 is not None
+        assert "suggestions" in chunk1.meta
+
+    with SessionLocal() as db:
+        proj = db.get(Project, PROJECT_ID_1)
+        assert proj is not None
+        proj.use_rules_suggestor = False
+        db.commit()
+
+    html2 = "<html><body>Step 2: start ERROR INC-99 on 2024-01-02</body></html>".encode(
+        "utf-8"
+    )
+    resp2 = client.post(
+        "/ingest",
+        data={"project_id": pid},
+        files={"file": ("b.html", html2, "text/html")},
+    )
+    doc2 = resp2.json()["doc_id"]
+    worker_main.parse_document(doc2)
+    with SessionLocal() as db:
+        chunk2 = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc2))
+        assert chunk2 is not None
+        assert "suggestions" not in chunk2.meta
+
+
+def test_exporter_respects_settings_toggle(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    _add_taxonomy(SessionLocal)
+    pid = str(PROJECT_ID_1)
+    _put_chunk(store, "d1")
+
+    template = "{{ chunk.metadata | tojson }}"
+    resp1 = client.post(
+        "/export/jsonl",
+        json={"project_id": pid, "doc_ids": ["d1"], "template": template},
+        headers={"X-Role": "curator"},
+    )
+    key1 = export_key(resp1.json()["export_id"], "data.jsonl")
+    data1 = store.get_bytes(key1).decode("utf-8").strip()
+    assert "suggestions" in data1
+
+    client.patch(
+        f"/projects/{pid}/settings",
+        json={"use_rules_suggestor": False},
+        headers={"X-Role": "curator"},
+    )
+    resp2 = client.post(
+        "/export/jsonl",
+        json={"project_id": pid, "doc_ids": ["d1"], "template": template},
+        headers={"X-Role": "curator"},
+    )
+    key2 = export_key(resp2.json()["export_id"], "data.jsonl")
+    data2 = store.get_bytes(key2).decode("utf-8").strip()
+    assert "suggestions" not in data2
+    assert resp1.json()["export_id"] != resp2.json()["export_id"]

--- a/worker/main.py
+++ b/worker/main.py
@@ -61,7 +61,10 @@ def parse_document(doc_id: str, request_id: str | None = None) -> None:
                 for ch in chunks:
                     if ch.content.type != "text":
                         continue
-                    remaining = project.max_suggestions_per_doc - total
+                    remaining = (
+                        project.max_suggestions_per_doc
+                        or settings.max_suggestions_per_doc
+                    ) - total
                     if remaining <= 0:
                         break
                     sugg = suggest(
@@ -69,7 +72,10 @@ def parse_document(doc_id: str, request_id: str | None = None) -> None:
                         use_rules_suggestor=project.use_rules_suggestor,
                         use_mini_llm=project.use_mini_llm,
                         max_suggestions=remaining,
-                        suggestion_timeout_ms=project.suggestion_timeout_ms,
+                        suggestion_timeout_ms=(
+                            project.suggestion_timeout_ms
+                            or settings.suggestion_timeout_ms
+                        ),
                     )
                     if sugg:
                         ch.metadata.setdefault("suggestions", {})


### PR DESCRIPTION
## Summary
- wire worker and exporters to per-project suggestion settings
- add API/project lookup for export endpoints
- cover project settings toggles with tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e4cbca50832baf295eaa6f25287a