### PR TITLE
[F2-01] Postman + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,33 @@
 [![CI](https://github.com/InstructifyAI/InstructifyAI/actions/workflows/ci.yml/badge.svg)](https://github.com/InstructifyAI/InstructifyAI/actions/workflows/ci.yml)
 [![Coverage](coverage.svg)](coverage.svg)
 
+## Quick Start (WSL2 & macOS)
+
+1. Ensure Docker Desktop is running. On Windows, use a WSL2 terminal; on macOS use the native shell.
+2. Start the stack:
+   ```bash
+   make dev
+   ```
+3. Apply database migrations:
+   ```bash
+   make migrate
+   ```
+4. (Optional) Run the demo on bundled samples:
+   ```bash
+   make demo
+   ```
+5. Launch Label Studio and configure the webhook:
+   - `docker run -it -p 8080:8080 heartexlabs/label-studio:latest`
+   - Open <http://localhost:8080> and add a webhook pointing to `http://host.docker.internal:8000/webhooks/label-studio`.
+6. Import the Postman collection and environment from `docs/postman/` or try the API with curl:
+   ```bash
+   curl http://localhost:8000/health
+   curl -X POST http://localhost:8000/export/jsonl \
+     -H "Authorization: Bearer $JWT" \
+     -H "Content-Type: application/json" \
+     -d '{"doc_ids":["DOC_ID"]}'
+   ```
+
 ## Curation API
 
 Phase‑1 exposes endpoints for managing a per‑project taxonomy and for applying

--- a/STATUS.md
+++ b/STATUS.md
@@ -76,6 +76,7 @@
 | E9-03 | Project settings wiring | codex | ☑ Done | [PR](#) |  |
 | E9-04 | Project onboarding API | codex | ☑ Done | PR TBD |  |
 | F1-01 | CI pipeline | codex | ☑ Done | [PR](#) |  |
+| F2-01 | Postman pack + README | codex | ☑ Done | [PR](#) |  |
 | E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
 
 ---

--- a/docs/postman/instructifyai.postman_collection.json
+++ b/docs/postman/instructifyai.postman_collection.json
@@ -1,0 +1,59 @@
+{
+  "info": {
+    "_postman_id": "00000000-0000-0000-0000-000000000000",
+    "name": "InstructifyAI API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/health",
+          "host": ["{{baseUrl}}"],
+          "path": ["health"]
+        }
+      }
+    },
+    {
+      "name": "Create Project",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"},
+          {"key": "Authorization", "value": "Bearer {{jwt}}"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"demo\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/projects",
+          "host": ["{{baseUrl}}"],
+          "path": ["projects"]
+        }
+      }
+    },
+    {
+      "name": "Export JSONL",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"},
+          {"key": "Authorization", "value": "Bearer {{jwt}}"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"doc_ids\": [\"DOC_ID\"]\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/export/jsonl",
+          "host": ["{{baseUrl}}"],
+          "path": ["export", "jsonl"]
+        }
+      }
+    }
+  ]
+}

--- a/docs/postman/instructifyai.postman_environment.json
+++ b/docs/postman/instructifyai.postman_environment.json
@@ -1,0 +1,21 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "name": "InstructifyAI DEV",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8000",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "jwt",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-01-01T00:00:00Z",
+  "_postman_exported_using": "Postman/10.0.0"
+}


### PR DESCRIPTION
## Summary
- add Postman collection and environment for core API calls
- document WSL2/macOS quick start, demo flow, and export example
- update project status tracking

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ea991dac832ba815a7596c94afa3