### PR TITLE
[C10-00] Worker deps (tesseract + libs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.mypy_cache/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Quick Start (WSL2 & macOS)
 
-1. Ensure Docker Desktop is running. On Windows, use a WSL2 terminal; on macOS use the native shell.
+1. Ensure Docker Desktop is running. On Windows, use a WSL2 terminal (worker image installs Tesseract via apt); on macOS use the native shell.
 2. Start the stack:
    ```bash
    make dev

--- a/STATUS.md
+++ b/STATUS.md
@@ -79,6 +79,7 @@
 | F2-01 | Postman pack + README | codex | ☑ Done | [PR](#) |  |
 | E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
 | S2-01 | GET /projects list endpoint | codex | ☑ Done | PR TBD |  |
+| C10-00 | Worker deps (tesseract + libs) | codex | ☐ In Progress | [PR](#) |  |
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,9 @@ services:
       - .:/app
 
   worker:
-    build: .
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker
     command: celery -A worker.main worker --loglevel=info
     env_file: .env
     depends_on:

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["celery", "-A", "worker.main", "worker", "--loglevel=info"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ PyMuPDF
 beautifulsoup4
 jinja2
 psycopg2-binary
+pytesseract
+charset-normalizer
+lxml

--- a/tests/test_worker_imports.py
+++ b/tests/test_worker_imports.py
@@ -1,0 +1,23 @@
+import importlib
+import shutil
+
+import pytest
+
+MODULES = [
+    "fitz",
+    "pytesseract",
+    "charset_normalizer",
+    "bs4",
+    "lxml",
+    "httpx",
+]
+
+
+def test_python_deps_import() -> None:
+    for mod in MODULES:
+        pytest.importorskip(mod)
+
+
+@pytest.mark.skipif(shutil.which("tesseract") is None, reason="tesseract not installed")
+def test_tesseract_binary_present() -> None:
+    assert shutil.which("tesseract")

--- a/worker/main.py
+++ b/worker/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import subprocess
 from typing import Any
 
 import sqlalchemy as sa
@@ -25,6 +26,17 @@ SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 configure_logging()
 logger = logging.getLogger(__name__)
+
+
+def _log_tesseract_version() -> None:
+    try:
+        out = subprocess.check_output(["tesseract", "--version"], text=True)
+        logger.info("tesseract %s", out.splitlines()[0])
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("tesseract not available: %s", exc)
+
+
+_log_tesseract_version()
 
 
 def _get_store() -> ObjectStore:


### PR DESCRIPTION
## Summary
- add worker Dockerfile with tesseract-ocr and parsing libraries
- log `tesseract --version` during worker startup
- document WSL requirement for tesseract-based worker

## Design Note
- Worker image installs system `tesseract-ocr` and Python libs (`pytesseract`, `charset-normalizer`, `lxml`) so Celery tasks can OCR when needed.
- Docker Compose now builds worker from a separate Dockerfile; API build untouched.
- Startup logs the tesseract version to confirm the binary is present. No migrations or settings changes required.

## Testing
- `python -m black tests/test_worker_imports.py worker/main.py` *(passed)*
- `python -m isort .` *(passed)*
- `make test` *(fails: coverage not installed in environment)*
- `pytest tests/test_worker_imports.py -q` *(fails: missing PyMuPDF dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b2d6fea0832bb21c88aeaefb2cfd