### PR TITLE
[C10-00] Worker deps (tesseract + libs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
    ```bash
    make dev
    ```
+   If you change worker dependencies or the Dockerfile, rebuild the image (run in WSL on Windows):
+   ```bash
+   docker compose build worker
+   ```
 3. Apply database migrations:
    ```bash
    make migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,9 @@ services:
       - .:/app
 
   worker:
-    build: .
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker
     command: celery -A worker.main worker --loglevel=info
     env_file: .env
     depends_on:

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Tesseract OCR and required libraries
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tesseract-ocr \
+    libtesseract-dev \
+    libleptonica-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies for the worker
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    pytesseract \
+    charset-normalizer \
+    lxml
+
+# Copy application code
+COPY . .
+
+CMD ["celery", "-A", "worker.main", "worker", "--loglevel=info"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ PyMuPDF
 beautifulsoup4
 jinja2
 psycopg2-binary
+pytesseract
+charset-normalizer
+lxml

--- a/tests/test_worker_imports.py
+++ b/tests/test_worker_imports.py
@@ -1,0 +1,14 @@
+def test_worker_dependencies_import() -> None:
+    import importlib
+
+    modules = [
+        "fitz",  # PyMuPDF
+        "pytesseract",
+        "charset_normalizer",
+        "bs4",
+        "lxml",
+        "httpx",
+    ]
+
+    for mod in modules:
+        assert importlib.import_module(mod) is not None

--- a/worker/main.py
+++ b/worker/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import subprocess
 from typing import Any
 
 import sqlalchemy as sa
@@ -25,6 +26,14 @@ SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 configure_logging()
 logger = logging.getLogger(__name__)
+
+try:
+    version = subprocess.check_output(
+        ["tesseract", "--version"], text=True
+    ).splitlines()[0]
+    logger.info("tesseract --version: %s", version)
+except Exception as exc:  # noqa: BLE001
+    logger.warning("tesseract --version failed: %s", exc)
 
 
 def _get_store() -> ObjectStore:


### PR DESCRIPTION
## Summary
- add worker Dockerfile with Tesseract OCR and parsing deps
- log `tesseract --version` on worker startup
- document WSL rebuild steps

## Testing
- `make lint` *(fails: mypy errors in api/main.py)*
- `make test` *(fails: coverage command not found)*
- `docker compose build worker` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6df9e5884832ba096543f41c858cb