### PR TITLE
[C10-01] Celery Canvas orchestrator

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -79,6 +79,7 @@
 | F2-01 | Postman pack + README | codex | ☑ Done | [PR](#) |  |
 | E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
 | S2-01 | GET /projects list endpoint | codex | ☑ Done | PR TBD |  |
+| C10-01 | Celery Canvas orchestrator | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ import mimetypes
 import urllib.request
 import uuid
 from datetime import datetime
-from typing import Any, Iterable
+from typing import Any, Iterable, cast
 
 import sqlalchemy as sa
 from fastapi import (
@@ -139,8 +139,8 @@ def list_projects(
             id=proj.id,
             name=proj.name,
             slug=proj.slug,
-            created_at=proj.created_at,
-            updated_at=proj.created_at,
+            created_at=cast(datetime, proj.created_at),
+            updated_at=cast(datetime, proj.created_at),
         )
         for proj in rows
     ]

--- a/tests/test_orchestrator_flow.py
+++ b/tests/test_orchestrator_flow.py
@@ -1,0 +1,58 @@
+import pathlib
+
+import sqlalchemy as sa
+from celery.canvas import chord  # type: ignore[import-untyped]
+
+from models import Audit, DocumentStatus, DocumentVersion
+from tests.conftest import PROJECT_ID_1
+from worker import flow
+from worker import main as worker_main
+from worker.tasks import utils as task_utils
+
+BASE = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _setup_worker(store, SessionLocal) -> None:
+    worker_main.create_client = lambda **kwargs: store.client
+    worker_main.settings.s3_bucket = store.bucket
+    worker_main.SessionLocal = SessionLocal
+    task_utils.SessionLocal = SessionLocal
+
+
+def test_flow_updates_status_and_audits(test_app):
+    client, store, _, SessionLocal = test_app
+    _setup_worker(store, SessionLocal)
+
+    data = (BASE / "examples/golden/sample.pdf").read_bytes()
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("sample.pdf", data, "application/pdf")},
+    )
+    doc_id = resp.json()["doc_id"]
+
+    sig = flow.build_flow(doc_id, request_id="rid")
+    sig.apply()
+
+    with SessionLocal() as db:
+        dv = db.scalar(
+            sa.select(DocumentVersion).where(DocumentVersion.document_id == doc_id)
+        )
+        assert dv is not None
+        assert dv.status == DocumentStatus.PARSED.value
+        audits = db.query(Audit).filter_by(chunk_id=doc_id).all()
+        assert [a.action for a in audits] == [
+            "preflight",
+            "normalize",
+            "extract",
+            "structure",
+            "chunk_write",
+            "finalize",
+        ]
+        assert all(a.request_id == "rid" for a in audits)
+
+
+def test_build_flow_with_ocr_uses_chord():
+    sig = flow.build_flow("doc1", do_ocr=True)
+    tasks = sig.tasks
+    assert isinstance(tasks[3], chord)

--- a/worker/flow.py
+++ b/worker/flow.py
@@ -1,0 +1,37 @@
+from typing import Any, cast
+
+from celery import chain, chord, group  # type: ignore[import-untyped]
+
+from worker.tasks.chunk_write import chunk_write
+from worker.tasks.extract import extract
+from worker.tasks.finalize import finalize
+from worker.tasks.normalize import normalize
+from worker.tasks.ocr import ocr_page
+from worker.tasks.preflight import preflight
+from worker.tasks.structure import structure
+
+
+def build_flow(
+    doc_id: str,
+    *,
+    request_id: str | None = None,
+    do_ocr: bool = False,
+):
+    """Build the Celery Canvas pipeline for parsing."""
+    steps = [
+        cast(Any, preflight).s(doc_id, request_id=request_id),
+        cast(Any, normalize).s(request_id=request_id),
+        cast(Any, extract).s(request_id=request_id),
+    ]
+    if do_ocr:
+        ocr_group = group(cast(Any, ocr_page).s(doc_id, request_id=request_id))
+        steps.append(chord(ocr_group, cast(Any, structure).s(request_id=request_id)))
+    else:
+        steps.append(cast(Any, structure).s(request_id=request_id))
+    steps.extend(
+        [
+            cast(Any, chunk_write).s(request_id=request_id),
+            cast(Any, finalize).s(request_id=request_id),
+        ]
+    )
+    return chain(*steps)

--- a/worker/tasks/chunk_write.py
+++ b/worker/tasks/chunk_write.py
@@ -1,0 +1,12 @@
+from worker.derived_writer import write_chunks
+from worker.main import _get_store, app
+
+from .utils import update_status
+
+
+@app.task
+def chunk_write(doc_id: str, request_id: str | None = None) -> str:
+    update_status(doc_id, "chunk_write", request_id)
+    store = _get_store()
+    write_chunks(store, doc_id, [])
+    return doc_id

--- a/worker/tasks/extract.py
+++ b/worker/tasks/extract.py
@@ -1,0 +1,9 @@
+from worker.main import app
+
+from .utils import update_status
+
+
+@app.task
+def extract(doc_id: str, request_id: str | None = None) -> str:
+    update_status(doc_id, "extract", request_id)
+    return doc_id

--- a/worker/tasks/finalize.py
+++ b/worker/tasks/finalize.py
@@ -1,0 +1,10 @@
+from models import DocumentStatus
+from worker.main import app
+
+from .utils import update_status
+
+
+@app.task
+def finalize(doc_id: str, request_id: str | None = None) -> str:
+    update_status(doc_id, DocumentStatus.PARSED.value, request_id, action="finalize")
+    return doc_id

--- a/worker/tasks/normalize.py
+++ b/worker/tasks/normalize.py
@@ -1,0 +1,9 @@
+from worker.main import app
+
+from .utils import update_status
+
+
+@app.task
+def normalize(doc_id: str, request_id: str | None = None) -> str:
+    update_status(doc_id, "normalize", request_id)
+    return doc_id

--- a/worker/tasks/ocr.py
+++ b/worker/tasks/ocr.py
@@ -1,0 +1,9 @@
+from worker.main import app
+
+from .utils import update_status
+
+
+@app.task
+def ocr_page(doc_id: str, request_id: str | None = None) -> str:
+    update_status(doc_id, "ocr", request_id)
+    return doc_id

--- a/worker/tasks/preflight.py
+++ b/worker/tasks/preflight.py
@@ -1,0 +1,9 @@
+from worker.main import app
+
+from .utils import update_status
+
+
+@app.task
+def preflight(doc_id: str, request_id: str | None = None) -> str:
+    update_status(doc_id, "preflight", request_id)
+    return doc_id

--- a/worker/tasks/structure.py
+++ b/worker/tasks/structure.py
@@ -1,0 +1,11 @@
+from worker.main import app
+
+from .utils import update_status
+
+
+@app.task
+def structure(doc_id: str | list[str], request_id: str | None = None) -> str:
+    if isinstance(doc_id, list):
+        doc_id = doc_id[0]
+    update_status(doc_id, "structure", request_id)
+    return doc_id

--- a/worker/tasks/utils.py
+++ b/worker/tasks/utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from core.correlation import set_request_id
+from models import Audit, DocumentVersion
+from worker.main import SessionLocal
+
+
+def update_status(
+    doc_id: str,
+    status: str,
+    request_id: str | None,
+    *,
+    action: str | None = None,
+) -> None:
+    """Update DocumentVersion.status and append an audit."""
+    set_request_id(request_id)
+    with SessionLocal() as db:
+        dv = db.scalar(
+            sa.select(DocumentVersion).where(DocumentVersion.document_id == doc_id)
+        )
+        if dv is None:
+            return
+        before = {"status": dv.status}
+        dv.status = status
+        db.add(dv)
+        db.add(
+            Audit(
+                chunk_id=doc_id,
+                user="system",
+                action=action or status,
+                before=before,
+                after={"status": status},
+                request_id=request_id,
+            )
+        )
+        db.commit()


### PR DESCRIPTION
## Summary
- add Celery Canvas flow chaining preflight through finalize with optional OCR chord
- persist DocumentVersion status with audit records per stage
- cover orchestrator behaviour with tests

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*
- `pytest tests/test_orchestrator_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6e2041dc0832ba1645581c8ca146f