### PR TITLE
[C10-02] Preflight & normalization

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -80,6 +80,7 @@
 | E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
 | S2-01 | GET /projects list endpoint | codex | ☑ Done | PR TBD |  |
 | C10-01 | Celery Canvas orchestrator | codex | ☑ Done | PR TBD |  |
+| C10-02 | Preflight & normalization | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/parser_pipeline/normalize.py
+++ b/parser_pipeline/normalize.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unicodedata
+
+from sqlalchemy.orm import Session
+
+from models import DocumentVersion
+
+
+def normalize(
+    db: Session,
+    doc_version: DocumentVersion,
+    data: bytes,
+    encoding: str,
+) -> str:
+    text = data.decode(encoding, errors="replace")
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = unicodedata.normalize("NFKC", text)
+    cleaned: list[str] = []
+    control_count = 0
+    for ch in text:
+        if unicodedata.category(ch) == "Cc" and ch not in "\n\t":
+            control_count += 1
+            continue
+        cleaned.append(ch)
+    result = "".join(cleaned)
+    meta = dict(doc_version.meta)
+    parse_meta = dict(meta.get("parse", {}))
+    parse_meta.update({"control_char_count": control_count})
+    meta["parse"] = parse_meta
+    doc_version.meta = meta
+    db.add(doc_version)
+    db.commit()
+    return result
+
+
+__all__ = ["normalize"]

--- a/parser_pipeline/preflight.py
+++ b/parser_pipeline/preflight.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import mimetypes
+from dataclasses import dataclass
+
+from charset_normalizer import from_bytes
+from sqlalchemy.orm import Session
+
+from models import DocumentVersion
+
+
+@dataclass
+class PreflightResult:
+    mime: str
+    encoding: str
+    non_utf8_ratio: float
+
+
+def _detect_mime(filename: str | None, head: bytes) -> str:
+    if head.startswith(b"%PDF"):
+        return "application/pdf"
+    if b"<html" in head.lower() or head.lstrip().startswith(b"<!DOCTYPE html"):
+        return "text/html"
+    if filename:
+        guess, _ = mimetypes.guess_type(filename)
+        if guess:
+            return guess
+    return "application/octet-stream"
+
+
+def preflight(
+    db: Session,
+    doc_version: DocumentVersion,
+    data: bytes,
+    filename: str | None = None,
+) -> PreflightResult:
+    head = data[:4096]
+    mime = _detect_mime(filename, head)
+    best = from_bytes(head).best()
+    encoding = best.encoding if best and best.encoding else "utf-8"
+    try:
+        data.decode("utf-8")
+        non_utf8_ratio = 0.0
+    except UnicodeDecodeError:
+        decoded = data.decode("utf-8", errors="ignore")
+        non_utf8_ratio = (len(data) - len(decoded.encode("utf-8"))) / len(data)
+    meta = dict(doc_version.meta)
+    parse_meta = dict(meta.get("parse", {}))
+    parse_meta.update({"non_utf8_ratio": non_utf8_ratio})
+    meta["parse"] = parse_meta
+    doc_version.meta = meta
+    db.add(doc_version)
+    db.commit()
+    return PreflightResult(mime=mime, encoding=encoding, non_utf8_ratio=non_utf8_ratio)
+
+
+__all__ = ["PreflightResult", "preflight"]

--- a/tests/test_preflight_normalize.py
+++ b/tests/test_preflight_normalize.py
@@ -1,0 +1,54 @@
+import hashlib
+import uuid
+
+from models import Document, DocumentStatus, DocumentVersion
+from parser_pipeline.normalize import normalize
+from parser_pipeline.preflight import preflight
+from tests.conftest import PROJECT_ID_1
+
+
+def _create_doc(db, data: bytes) -> DocumentVersion:
+    doc_id = str(uuid.uuid4())
+    dv_id = str(uuid.uuid4())
+    doc = Document(
+        id=doc_id, project_id=PROJECT_ID_1, source_type="txt", latest_version_id=dv_id
+    )
+    dv = DocumentVersion(
+        id=dv_id,
+        document_id=doc_id,
+        project_id=PROJECT_ID_1,
+        version=1,
+        doc_hash=hashlib.sha256(data).hexdigest(),
+        mime="application/octet-stream",
+        size=len(data),
+        status=DocumentStatus.INGESTED.value,
+        meta={},
+    )
+    db.add_all([doc, dv])
+    db.commit()
+    return dv
+
+
+def test_preflight_detects_non_utf8_and_records_metric(test_app) -> None:
+    _, _, _, SessionLocal = test_app
+    data = ("Caf\xe9 " * 3).encode("latin-1")
+    with SessionLocal() as db:
+        dv = _create_doc(db, data)
+        res = preflight(db, dv, data, "x.txt")
+        assert res.encoding.lower() != "utf-8"
+        assert dv.meta["parse"]["non_utf8_ratio"] > 0
+        text = normalize(db, dv, data, res.encoding)
+        assert "Café" in text
+        assert dv.meta["parse"].get("control_char_count", 0) == 0
+
+
+def test_normalize_strips_controls_and_nfkc(test_app) -> None:
+    _, _, _, SessionLocal = test_app
+    raw = "Line1\rLine2\x00\tLine3\x1fLigature: ﬁ".encode("utf-8")
+    with SessionLocal() as db:
+        dv = _create_doc(db, raw)
+        res = preflight(db, dv, raw, "y.txt")
+        text = normalize(db, dv, raw, res.encoding)
+        assert text == "Line1\nLine2\tLine3Ligature: fi"
+        assert dv.meta["parse"]["control_char_count"] == 2
+        assert dv.meta["parse"].get("non_utf8_ratio", 0) == 0


### PR DESCRIPTION
## Summary
- add preflight step to detect mime/encoding and log non-UTF8 ratio
- normalize text to UTF-8/NFKC and strip control characters
- record parse metrics on DocumentVersion and test preflight/normalize

## Testing
- `make lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6e6cdc5e4832b9497d3bc226122f6