### PR TITLE
[C10-03] PDF extractor v2 + OCR

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -81,6 +81,7 @@
 | S2-01 | GET /projects list endpoint | codex | ☑ Done | PR TBD |  |
 | C10-01 | Celery Canvas orchestrator | codex | ☑ Done | PR TBD |  |
 | C10-02 | Preflight & normalization | codex | ☑ Done | PR TBD |  |
+| C10-03 | PDF extractor v2 + OCR | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/parsers/pdf_v2.py
+++ b/parsers/pdf_v2.py
@@ -1,0 +1,85 @@
+import io
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, List, Optional
+
+import fitz  # type: ignore[import-not-found, import-untyped]
+import pytesseract  # type: ignore[import-untyped]
+from PIL import Image
+
+
+@dataclass
+class Block:
+    text: str
+    kind: str
+    meta: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class PageMetrics:
+    page: int
+    ocr_used: bool
+    ocr_conf_mean: Optional[float]
+
+
+class PDFParserV2:
+    def __init__(self, *, lang: str = "eng") -> None:
+        self.lang = lang
+        self.page_metrics: List[PageMetrics] = []
+
+    def parse(self, data: bytes) -> Iterator[Block]:
+        doc = fitz.open(stream=data, filetype="pdf")
+        for page_index, page in enumerate(doc, start=1):
+            pdf_text = page.get_text("text")
+            text_len = len(pdf_text.strip())
+            image_count = len(page.get_images(full=True))
+
+            ocr_used = False
+            ocr_conf_mean: Optional[float] = None
+            ocr_text = ""
+            if text_len < 50 and image_count > 0:
+                ocr_text, ocr_conf_mean = self._ocr_page(page)
+                ocr_used = True
+
+            self.page_metrics.append(
+                PageMetrics(
+                    page=page_index, ocr_used=ocr_used, ocr_conf_mean=ocr_conf_mean
+                )
+            )
+
+            for line in pdf_text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                kind = "title" if line.isupper() else "text"
+                yield Block(
+                    text=line,
+                    kind=kind,
+                    meta={"page": page_index, "source_stage": "pdf_text"},
+                )
+
+            if ocr_used:
+                for line in ocr_text.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    kind = "title" if line.isupper() else "text"
+                    yield Block(
+                        text=line,
+                        kind=kind,
+                        meta={"page": page_index, "source_stage": "pdf_ocr"},
+                    )
+
+    def _ocr_page(self, page: fitz.Page) -> tuple[str, Optional[float]]:
+        pix = page.get_pixmap(dpi=300)
+        img = Image.open(io.BytesIO(pix.tobytes("png")))
+        data = pytesseract.image_to_data(
+            img, lang=self.lang, output_type=pytesseract.Output.DICT
+        )
+        words = [w.strip() for w in data["text"] if w.strip()]
+        confs = [float(c) for c in data["conf"] if c not in {"-1", ""}]
+        text = " ".join(words)
+        conf_mean = sum(confs) / len(confs) if confs else None
+        return text, conf_mean
+
+
+__all__ = ["Block", "PageMetrics", "PDFParserV2"]

--- a/tests/test_pdf_v2_ocr.py
+++ b/tests/test_pdf_v2_ocr.py
@@ -1,0 +1,48 @@
+import base64
+
+import pytest
+
+pytest.importorskip("fitz")
+pytest.importorskip("pytesseract")
+
+import fitz  # type: ignore[import-not-found, import-untyped]
+import pytesseract  # type: ignore[import-untyped]
+
+from parsers.pdf_v2 import PDFParserV2
+
+IMAGE_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAGQAAAAoCAIAAACHGsgUAAAB+UlEQVR4nO3Yv6uyUBjA8YyXgpYgqMH2gqJFpziDmuLSFASNTY3N/SVNDdUS/QVhP4YarE1CCILG2m3KMPLcQa5c3vcle6Dw3svzmfR0isO3ziFkKKUR9Jxo2Av4STAWAMYCwFgAGAsAYwFgLACMBYCxADAWAMYCCI7V7/d5ni+XyzzPD4dDb7DX63EcJwhCtVo9Ho/eYCKREEVREASO41ar1RtXHRb6kKZphBDLsiillmURQubz+Ww2kyTpcrlQSieTSaVS8SYnk0nvwjTNUqn0+JN/ooBYsiyv12v/Vtd1RVFUVd1sNv5gq9VyHId+ieW6biqVev1iwxYQi2VZ27b9W9u2WZbNZrPX6/XfyX4sTdPq9frrFvld/IHuWYZh7vf7f191HEcUxdvttt/vd7vdKw6J7yXggC8UCoZh+LeGYRSLxVwut91uvRFKabPZ9K5jsdhyudR1vdPpDAaDt6w3XI9/eNPplBByPp/p5wG/WCzG47GiKN5OHI1GjUbDm+xvQ8MwarXa23ZDaAK2oaqqp9NJkqR4PO44TrvdlmU5EokcDgee59PpdCaT6Xa7f70rn8+bpum6bjT6q/7HMRSfwT/tV33z74axADAWAMYCwFgAGAsAYwFgLACMBYCxADAWAMYCwFgAGAsAYwFgLACMBYCxADAWwAeEQLqnJKe0wQAAAABJRU5ErkJggg=="
+
+
+def _tesseract_available() -> bool:
+    try:
+        pytesseract.get_tesseract_version()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _tesseract_available(), reason="tesseract not installed")
+def test_pdf_v2_ocr() -> None:
+    doc = fitz.open()
+
+    # Page 1: regular text
+    page1 = doc.new_page()
+    page1.insert_text((72, 72), "HELLO\nworld")
+
+    # Page 2: image with text
+    page2 = doc.new_page()
+    image_bytes = base64.b64decode(IMAGE_PNG_BASE64)
+    page2.insert_image(fitz.Rect(0, 0, 100, 40), stream=image_bytes)
+
+    pdf_bytes = doc.tobytes()
+    doc.close()
+
+    parser = PDFParserV2(lang="eng")
+    blocks = list(parser.parse(pdf_bytes))
+
+    assert any(b.meta["source_stage"] == "pdf_text" for b in blocks)
+    assert any(b.meta["source_stage"] == "pdf_ocr" for b in blocks)
+
+    assert parser.page_metrics[0].ocr_used is False
+    assert parser.page_metrics[1].ocr_used is True
+    assert parser.page_metrics[1].ocr_conf_mean is not None


### PR DESCRIPTION
## Summary
- add PDFParserV2 with per-page OCR fallback and metrics
- cover OCR fallback with unit test using an image-only page
- note task completion in STATUS.md

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*
- `pytest tests/test_pdf_v2_ocr.py -vv` *(skipped: tesseract not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eb1b86cc832b80e45640ff71bf97