### PR TITLE
[C10-06] HTML crawl ingest + parse

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -84,6 +84,7 @@
 | C10-03 | PDF extractor v2 + OCR | codex | ☑ Done | PR TBD |  |
 | C10-04 | UTF coverage metrics | codex | ☑ Done | PR TBD |  |
 | C10-05 | HTML ZIP ingest + parse | codex | ☑ Done | PR TBD |  |
+| C10-06 | HTML crawl ingest + parse | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -118,3 +118,11 @@ class ExportResponse(BaseModel):
 
 class MetricsResponse(BaseModel):
     curation_completeness: float
+
+
+class CrawlPayload(BaseModel):
+    project_id: str
+    base_url: str
+    allow_prefix: str | None = None
+    max_depth: int
+    max_pages: int

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,5 +1,6 @@
 from . import html as _html  # noqa: F401
 from . import html_bundle as _html_bundle  # noqa: F401
+from . import html_crawl as _html_crawl  # noqa: F401
 from . import pdf as _pdf  # noqa: F401
 from .registry import registry
 

--- a/parsers/html_crawl.py
+++ b/parsers/html_crawl.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+
+from storage.object_store import raw_key
+
+from .html import HTMLParser
+from .registry import registry
+
+
+@registry.register("application/x-crawl")  # type: ignore[arg-type]
+class HTMLCrawlParser:
+    @staticmethod
+    def parse(data: bytes, *, store, doc_id: str):
+        index = json.loads(data.decode("utf-8"))
+        for url, filename in index.items():
+            page_bytes = store.get_bytes(raw_key(doc_id, f"crawl/{filename}"))
+            for blk in HTMLParser.parse(page_bytes):
+                blk.metadata["file_path"] = filename
+                blk.metadata["url"] = url
+                yield blk
+
+
+__all__ = ["HTMLCrawlParser"]

--- a/tests/test_ingest_crawl.py
+++ b/tests/test_ingest_crawl.py
@@ -1,0 +1,74 @@
+import json
+
+import httpx
+
+from storage.object_store import derived_key, raw_key
+from tests.conftest import PROJECT_ID_1
+from worker import main as worker_main
+
+
+def _setup_worker(store, SessionLocal):
+    worker_main.create_client = lambda **kwargs: store.client
+    worker_main.settings.s3_bucket = store.bucket
+    worker_main.SessionLocal = SessionLocal
+
+
+def test_ingest_crawl(test_app) -> None:
+    client, store, calls, SessionLocal = test_app
+    crawl_calls: list[tuple[str, str, str | None, int, int, str | None]] = []
+    worker_main.crawl_document.delay = lambda doc_id, base_url, allow_prefix, max_depth, max_pages, request_id=None: crawl_calls.append(
+        (doc_id, base_url, allow_prefix, max_depth, max_pages, request_id)
+    )
+
+    resp = client.post(
+        "/ingest/crawl",
+        json={
+            "project_id": str(PROJECT_ID_1),
+            "base_url": "http://example.com/a",
+            "allow_prefix": "/",
+            "max_depth": 2,
+            "max_pages": 5,
+        },
+    )
+    assert resp.status_code == 200
+    doc_id = resp.json()["doc_id"]
+    assert crawl_calls and crawl_calls[0][0] == doc_id
+
+    _setup_worker(store, SessionLocal)
+
+    def mock_get(url, *args, **kwargs):
+        class Resp:
+            def __init__(self, text: str):
+                self.status_code = 200
+                self.text = text
+                self.content = text.encode("utf-8")
+                self.headers = {"content-type": "text/html"}
+
+        if url == "http://example.com/a":
+            return Resp(
+                '<html><body><p>A</p><a href="/b">B</a><a href="/a">A</a></body></html>'
+            )
+        if url == "http://example.com/b":
+            return Resp('<html><body><p>B</p><a href="/a">A</a></body></html>')
+        return Resp("<html></html>")
+
+    httpx.get = mock_get
+
+    worker_main.parse_document.delay = (
+        lambda doc_id, request_id=None: worker_main.parse_document(doc_id)
+    )
+    worker_main.crawl_document(doc_id, "http://example.com/a", "/", 2, 5)
+
+    assert raw_key(doc_id, "crawl/page0.html") in store.client.store
+    assert raw_key(doc_id, "crawl/page1.html") in store.client.store
+    index = json.loads(store.client.store[raw_key(doc_id, "crawl/crawl_index.json")])
+    assert len(index) == 2
+
+    chunks_key = derived_key(doc_id, "chunks.jsonl")
+    assert chunks_key in store.client.store
+    lines = store.client.store[chunks_key].decode("utf-8").strip().splitlines()
+    metas = [json.loads(line)["metadata"] for line in lines]
+    urls = {m["url"] for m in metas}
+    paths = {m["file_path"] for m in metas}
+    assert {"http://example.com/a", "http://example.com/b"} <= urls
+    assert {"page0.html", "page1.html"} <= paths


### PR DESCRIPTION
## Summary
- add /ingest/crawl endpoint for HTML crawling
- implement crawler worker and parser to store and parse crawled pages
- cover HTML crawl ingest with tests and docs

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b8d5194832bb384521b31bec57a