### PR TITLE
[C10-07] Structure inference v2

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -85,6 +85,7 @@
 | C10-04 | UTF coverage metrics | codex | ☑ Done | PR TBD |  |
 | C10-05 | HTML ZIP ingest + parse | codex | ☑ Done | PR TBD |  |
 | C10-06 | HTML crawl ingest + parse | codex | ☑ Done | PR TBD |  |
+| C10-07 | Structure inference v2 | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/parser_pipeline/structure.py
+++ b/parser_pipeline/structure.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import statistics
+from typing import Iterator, List
+
+from chunking.chunker import Block
+
+try:  # optional deps in some environments
+    import fitz  # type: ignore[import-not-found, import-untyped]
+except Exception:  # pragma: no cover - handled via importorskip in tests
+    fitz = None  # type: ignore
+
+try:
+    from bs4 import BeautifulSoup, NavigableString, Tag  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover - handled via importorskip in tests
+    BeautifulSoup = NavigableString = Tag = None  # type: ignore
+
+
+def _html_blocks(data: bytes) -> Iterator[Block]:
+    soup = BeautifulSoup(data, "html.parser")
+    for tag in soup.find_all(["nav", "footer", "aside"]):
+        tag.decompose()
+    stack: List[str] = []
+
+    def traverse(node) -> Iterator[Block]:
+        for child in node.children:
+            if isinstance(child, NavigableString):
+                text = str(child).strip()
+                if text:
+                    yield Block(text=text, section_path=stack.copy())
+            elif isinstance(child, Tag):
+                name = child.name.lower()
+                if name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+                    level = int(name[1])
+                    text = child.get_text(" ", strip=True)
+                    stack[:] = stack[: level - 1]
+                    stack.append(text)
+                    yield Block(
+                        text=text,
+                        section_path=stack.copy(),
+                        metadata={"kind": "title"},
+                    )
+                elif name == "table":
+                    yield Block(
+                        text="",
+                        type="table_placeholder",
+                        section_path=stack.copy(),
+                    )
+                elif name == "pre":
+                    text = child.get_text("", strip=False)
+                    if text:
+                        yield Block(text=text, section_path=stack.copy())
+                else:
+                    yield from traverse(child)
+        return
+
+    body = soup.body or soup
+    yield from traverse(body)
+
+
+def _pdf_blocks(data: bytes) -> Iterator[Block]:
+    if fitz is None:  # pragma: no cover - import guarded in tests
+        raise RuntimeError("PyMuPDF not installed")
+    doc = fitz.open(stream=data, filetype="pdf")
+    for page_index, page in enumerate(doc, start=1):
+        page_dict = page.get_text("dict")
+        sizes: List[float] = []
+        for blk in page_dict["blocks"]:
+            if blk.get("type") != 0:
+                continue
+            for line in blk["lines"]:
+                for span in line["spans"]:
+                    sizes.append(span["size"])
+        base = statistics.median(sizes) if sizes else 0
+        current_section: List[str] = []
+        first_line = True
+        for blk in page_dict["blocks"]:
+            if blk.get("type") != 0:
+                continue
+            block_text = "\n".join(
+                "".join(span["text"] for span in line["spans"]) for line in blk["lines"]
+            )
+            if any(ch in block_text for ch in ("|", "\t")) or "  " in block_text:
+                yield Block(
+                    text="",
+                    type="table_placeholder",
+                    page=page_index,
+                    section_path=current_section.copy(),
+                )
+                continue
+            for line in blk["lines"]:
+                spans = line["spans"]
+                line_text = "".join(span["text"] for span in spans).strip()
+                if not line_text:
+                    continue
+                line_size = max(span["size"] for span in spans)
+                if line_size > base * 1.2 or (first_line and not current_section):
+                    current_section = [line_text]
+                    yield Block(
+                        text=line_text,
+                        page=page_index,
+                        section_path=current_section.copy(),
+                        metadata={"kind": "title"},
+                    )
+                else:
+                    yield Block(
+                        text=line_text,
+                        page=page_index,
+                        section_path=current_section.copy(),
+                    )
+                first_line = False
+
+
+def structure(data: bytes, *, source_type: str) -> Iterator[Block]:
+    if source_type == "text/html":
+        yield from _html_blocks(data)
+    elif source_type == "application/pdf":
+        yield from _pdf_blocks(data)
+    else:  # pragma: no cover - defensive
+        raise ValueError(f"Unsupported source_type: {source_type}")
+
+
+__all__ = ["structure"]

--- a/tests/test_structure_infer.py
+++ b/tests/test_structure_infer.py
@@ -1,0 +1,29 @@
+import pathlib
+
+import pytest
+
+from parser_pipeline.structure import structure
+
+BASE = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load(path: str) -> bytes:
+    return (BASE / path).read_bytes()
+
+
+def test_html_structure_titles_and_tables() -> None:
+    pytest.importorskip("bs4")
+    data = _load("examples/golden/sample.html")
+    blocks = list(structure(data, source_type="text/html"))
+    assert blocks[0].metadata.get("kind") == "title"
+    assert blocks[0].section_path == ["Title"]
+    table_block = next(b for b in blocks if b.type == "table_placeholder")
+    assert table_block.section_path == ["Title", "Section A"]
+
+
+def test_pdf_structure_titles() -> None:
+    pytest.importorskip("fitz")
+    data = _load("examples/golden/sample.pdf")
+    blocks = list(structure(data, source_type="application/pdf"))
+    assert blocks[0].metadata.get("kind") == "title"
+    assert blocks[0].section_path == [blocks[0].text]


### PR DESCRIPTION
## Summary
- add parser_pipeline.structure with HTML heading hierarchy, PDF font-size titles, and table placeholders
- test structure inference for titles, section paths, and tables
- update STATUS for C10-07

## Testing
- `make lint`
- `make test` *(fails: coverage command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a72e59dc04832b87dbc13bcafb36e5