### PR TITLE
[C10-08] Chunker v2

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -86,6 +86,7 @@
 | C10-05 | HTML ZIP ingest + parse | codex | ☑ Done | PR TBD |  |
 | C10-06 | HTML crawl ingest + parse | codex | ☑ Done | PR TBD |  |
 | C10-07 | Structure inference v2 | codex | ☑ Done | PR TBD |  |
+| C10-08 | Chunker v2 | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/chunking/chunker_v2.py
+++ b/chunking/chunker_v2.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+def _normalize_text(text: str) -> str:
+    return " ".join(text.split()).lower()
+
+
+def _token_count(text: str) -> int:
+    return len(text.split())
+
+
+@dataclass
+class Block:
+    text: str
+    type: str = "text"  # "text" or "table_placeholder"
+    file_path: str | None = None
+    page: int | None = None
+    section_path: List[str] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class ChunkContent:
+    type: str
+    text: str | None = None
+
+
+@dataclass
+class Chunk:
+    id: uuid.UUID
+    order: int
+    content: ChunkContent
+    text_hash: str
+    metadata: dict = field(default_factory=dict)
+    rev: int = 1
+
+
+def _hash_text(content: ChunkContent) -> str:
+    text = content.text if content.type == "text" and content.text else content.type
+    return hashlib.sha256(_normalize_text(text).encode("utf-8")).hexdigest()
+
+
+def chunk_blocks(blocks: Iterable[Block], *, max_tokens: int = 900) -> List[Chunk]:
+    chunks: List[Chunk] = []
+    buf: List[str] = []
+    current_tokens = 0
+    start_page: int | None = None
+    current_section: List[str] = []
+    current_file: str | None = None
+
+    def flush() -> None:
+        nonlocal buf, current_tokens, start_page, current_section, current_file
+        if not buf:
+            return
+        text = "\n".join(buf).strip()
+        content = ChunkContent(type="text", text=text)
+        text_hash = _hash_text(content)
+        chunks.append(
+            Chunk(
+                id=uuid.uuid5(uuid.NAMESPACE_URL, text_hash),
+                order=len(chunks),
+                content=content,
+                text_hash=text_hash,
+                metadata={
+                    "file_path": current_file,
+                    "page": start_page,
+                    "section_path": current_section.copy(),
+                },
+            )
+        )
+        buf = []
+        current_tokens = 0
+        start_page = None
+        current_section = []
+        current_file = None
+
+    for block in blocks:
+        if block.type == "table_placeholder":
+            flush()
+            content = ChunkContent(type="table_placeholder", text=None)
+            text_hash = _hash_text(content)
+            chunks.append(
+                Chunk(
+                    id=uuid.uuid5(uuid.NAMESPACE_URL, text_hash),
+                    order=len(chunks),
+                    content=content,
+                    text_hash=text_hash,
+                    metadata={
+                        "file_path": block.file_path,
+                        "page": block.page,
+                        "section_path": block.section_path.copy(),
+                    },
+                )
+            )
+            continue
+
+        if block.file_path != current_file:
+            flush()
+        if block.metadata.get("kind") == "title":
+            flush()
+
+        tokens = _token_count(block.text)
+        if not buf:
+            start_page = block.page
+            current_section = block.section_path.copy()
+            current_file = block.file_path
+        buf.append(block.text)
+        current_tokens += tokens
+        if current_tokens >= max_tokens:
+            flush()
+
+    flush()
+    return chunks
+
+
+__all__ = ["Block", "Chunk", "ChunkContent", "chunk_blocks"]

--- a/tests/test_chunker_v2.py
+++ b/tests/test_chunker_v2.py
@@ -1,0 +1,47 @@
+from chunking.chunker_v2 import Block, chunk_blocks
+
+
+def _text(words: int) -> str:
+    return "word " * words
+
+
+def test_chunker_v2_boundaries_and_meta() -> None:
+    blocks = [
+        Block(text="intro", file_path="a.txt", page=1, section_path=["Intro"]),
+        Block(
+            text="Section A",
+            file_path="a.txt",
+            page=1,
+            section_path=["Section A"],
+            metadata={"kind": "title"},
+        ),
+        Block(
+            text="content one",
+            file_path="a.txt",
+            page=1,
+            section_path=["Section A"],
+        ),
+        Block(text="other", file_path="b.txt", page=2, section_path=["Other"]),
+    ]
+    chunks = chunk_blocks(blocks, max_tokens=50)
+    assert len(chunks) == 3
+    assert chunks[0].content.text == "intro"
+    assert chunks[1].content.text is not None
+    assert chunks[1].content.text.startswith("Section A\ncontent one")
+    assert chunks[2].metadata["file_path"] == "b.txt"
+    assert chunks[1].metadata == {
+        "file_path": "a.txt",
+        "page": 1,
+        "section_path": ["Section A"],
+    }
+
+
+def test_chunker_v2_deterministic() -> None:
+    blocks = [
+        Block(text=_text(10), file_path="a", page=1, section_path=["A"]),
+        Block(text=_text(10), file_path="a", page=1, section_path=["A"]),
+        Block(text=_text(10), file_path="b", page=1, section_path=["B"]),
+    ]
+    chunks1 = chunk_blocks(blocks, max_tokens=15)
+    chunks2 = chunk_blocks(blocks, max_tokens=15)
+    assert chunks1 == chunks2


### PR DESCRIPTION
## Summary
- implement deterministic multi-file chunker with ~900-token limit
- record file path, page, section path in chunk metadata
- add tests for boundary handling and determinism

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a73742e5e0832bbd6edd330272e4dc