### PR TITLE
[C10-09] Manifest & lineage

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -87,6 +87,7 @@
 | C10-06 | HTML crawl ingest + parse | codex | ☑ Done | PR TBD |  |
 | C10-07 | Structure inference v2 | codex | ☑ Done | PR TBD |  |
 | C10-08 | Chunker v2 | codex | ☑ Done | PR TBD |  |
+| C10-09 | Derived writer + manifest v2 | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/tests/test_manifest_v2.py
+++ b/tests/test_manifest_v2.py
@@ -1,0 +1,50 @@
+import json
+import uuid
+
+from chunking.chunker import Chunk, ChunkContent, ChunkSource
+from storage.object_store import derived_key
+from worker.derived_writer import upsert_chunks
+
+
+def test_manifest_v2_fields_and_presign(test_app):
+    _, store, _, SessionLocal = test_app
+    with SessionLocal() as db:
+        doc_id = str(uuid.uuid4())
+        chunks = [
+            Chunk(
+                id=uuid.uuid4(),
+                order=0,
+                content=ChunkContent(type="text", text="alpha"),
+                source=ChunkSource(page=1, section_path=[]),
+                text_hash="h1",
+                metadata={"file_path": "a.html"},
+            ),
+            Chunk(
+                id=uuid.uuid4(),
+                order=1,
+                content=ChunkContent(type="text", text="beta"),
+                source=ChunkSource(page=2, section_path=[]),
+                text_hash="h2",
+                metadata={"source_stage": "pdf_ocr"},
+            ),
+        ]
+        metrics = {"empty_chunk_ratio": 0.5}
+        chunks_url, manifest_url = upsert_chunks(
+            db,
+            store,
+            doc_id=doc_id,
+            version=1,
+            chunks=chunks,
+            metrics=metrics,
+        )
+    manifest_key = derived_key(doc_id, "manifest.json")
+    manifest = json.loads(store.client.store[manifest_key])
+    assert manifest["tool_versions"]["pymupdf"]
+    assert "tesseract" in manifest["tool_versions"]
+    assert manifest["thresholds"]["empty_chunk_ratio"] > 0
+    assert manifest["stage_metrics"]["empty_chunk_ratio"] == 0.5
+    assert manifest["files"] == ["a.html"]
+    assert manifest["pages_ocr"] == [2]
+    assert "created_at" in manifest
+    assert "X-Amz-Expires" in chunks_url
+    assert "X-Amz-Expires" in manifest_url

--- a/worker/main.py
+++ b/worker/main.py
@@ -20,7 +20,7 @@ from core.settings import get_settings
 from models import Document, DocumentStatus
 from parser_pipeline.metrics import char_coverage
 from parsers import registry
-from storage.object_store import ObjectStore, create_client, derived_key, raw_key
+from storage.object_store import ObjectStore, create_client, raw_key
 from worker.derived_writer import upsert_chunks
 from worker.suggestors import suggest
 
@@ -178,19 +178,8 @@ def parse_document(doc_id: str, request_id: str | None = None) -> None:
                 doc_id=doc_id,
                 version=ver.version,
                 chunks=chunks,
+                metrics=metrics,
             )
-            files = sorted(
-                {
-                    ch.metadata["file_path"]
-                    for ch in chunks
-                    if "file_path" in ch.metadata
-                }
-            )
-            if files:
-                manifest_key = derived_key(doc_id, "manifest.json")
-                store.put_bytes(
-                    manifest_key, json.dumps({"files": files}).encode("utf-8")
-                )
             enforce_quality_gates(doc_id, doc.project_id, ver.version, db)
             db.commit()
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- write chunks and manifest for derived docs, including tool versions, thresholds, stage metrics, files and OCR pages
- return presigned URLs for derived artifacts
- test manifest v2 fields and URL presigning

## Testing
- `make lint`
- `pytest`
- `make test` *(fails: coverage: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a73bc55238832b9ec2223fb64eb85f