### PR TITLE
[C10-11] Parser settings wiring

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -89,6 +89,7 @@
 | C10-08 | Chunker v2 | codex | ☑ Done | PR TBD |  |
 | C10-09 | Derived writer + manifest v2 | codex | ☑ Done | [PR](#) |  |
 | C10-10 | Metrics + gates v2 | codex | ☑ Done | [PR](#) |  |
+| C10-11 | Parser settings wiring | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -30,6 +30,7 @@ from api.schemas import (
     ExportPayload,
     ExportResponse,
     GuidelineField,
+    HtmlCrawlLimits,
     MetricsResponse,
     ProjectCreate,
     ProjectResponse,
@@ -164,6 +165,16 @@ def get_project_settings_endpoint(
         use_mini_llm=project.use_mini_llm,
         max_suggestions_per_doc=project.max_suggestions_per_doc,
         suggestion_timeout_ms=project.suggestion_timeout_ms,
+        ocr_langs=project.ocr_langs,
+        min_text_len_for_ocr=project.min_text_len_for_ocr,
+        html_crawl_limits=(
+            HtmlCrawlLimits(**project.html_crawl_limits)
+            if project.html_crawl_limits
+            else HtmlCrawlLimits(
+                max_depth=settings.html_crawl_max_depth,
+                max_pages=settings.html_crawl_max_pages,
+            )
+        ),
     )
 
 
@@ -193,6 +204,16 @@ def update_project_settings_endpoint(
         use_mini_llm=project.use_mini_llm,
         max_suggestions_per_doc=project.max_suggestions_per_doc,
         suggestion_timeout_ms=project.suggestion_timeout_ms,
+        ocr_langs=project.ocr_langs,
+        min_text_len_for_ocr=project.min_text_len_for_ocr,
+        html_crawl_limits=(
+            HtmlCrawlLimits(**project.html_crawl_limits)
+            if project.html_crawl_limits
+            else HtmlCrawlLimits(
+                max_depth=settings.html_crawl_max_depth,
+                max_pages=settings.html_crawl_max_pages,
+            )
+        ),
     )
 
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -89,11 +89,21 @@ class ProjectsListResponse(BaseModel):
     total: int
 
 
+class HtmlCrawlLimits(BaseModel):
+    max_depth: int
+    max_pages: int
+
+
 class ProjectSettings(BaseModel):
     use_rules_suggestor: bool = True
     use_mini_llm: bool = False
     max_suggestions_per_doc: int = 200
     suggestion_timeout_ms: int = 500
+    ocr_langs: List[str] = Field(default_factory=list)
+    min_text_len_for_ocr: int = 0
+    html_crawl_limits: HtmlCrawlLimits = Field(
+        default_factory=lambda: HtmlCrawlLimits(max_depth=2, max_pages=10)
+    )
 
 
 class ProjectSettingsUpdate(BaseModel):
@@ -101,6 +111,9 @@ class ProjectSettingsUpdate(BaseModel):
     use_mini_llm: bool | None = None
     max_suggestions_per_doc: int | None = None
     suggestion_timeout_ms: int | None = None
+    ocr_langs: List[str] | None = None
+    min_text_len_for_ocr: int | None = None
+    html_crawl_limits: HtmlCrawlLimits | None = None
 
 
 class ExportPayload(BaseModel):

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from typing import Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,6 +17,10 @@ class Settings(BaseSettings):
     export_signed_url_expiry_seconds: int = 600
     suggestion_timeout_ms: int = 500
     max_suggestions_per_doc: int = 200
+    ocr_langs: list[str] = Field(default_factory=list)
+    min_text_len_for_ocr: int = 0
+    html_crawl_max_depth: int = 2
+    html_crawl_max_pages: int = 10
     curation_completeness_threshold: float = 0.8
     empty_chunk_ratio_threshold: float = 0.1
     html_section_path_coverage_threshold: float = 0.9

--- a/models/project.py
+++ b/models/project.py
@@ -31,6 +31,13 @@ class Project(Base):
     suggestion_timeout_ms: Mapped[int] = mapped_column(
         sa.Integer, nullable=False, default=500, server_default=sa.text("500")
     )
+    ocr_langs: Mapped[list[str]] = mapped_column(sa.JSON, nullable=False, default=list)
+    min_text_len_for_ocr: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, default=0
+    )
+    html_crawl_limits: Mapped[dict[str, int]] = mapped_column(
+        sa.JSON, nullable=False, default=dict
+    )
     created_at: Mapped[sa.types.DateTime] = mapped_column(
         sa.DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/tests/test_parser_settings.py
+++ b/tests/test_parser_settings.py
@@ -1,0 +1,51 @@
+from sqlalchemy import select
+
+from models import DocumentVersion
+from tests.conftest import PROJECT_ID_1
+from worker import main as worker_main
+
+
+def _setup_worker(store, SessionLocal):
+    worker_main.create_client = lambda **kwargs: store.client
+    worker_main.settings.s3_bucket = store.bucket
+    worker_main.SessionLocal = SessionLocal
+
+
+def test_parser_settings_toggle(test_app) -> None:
+    client, store, calls, SessionLocal = test_app
+    resp = client.patch(
+        f"/projects/{PROJECT_ID_1}/settings",
+        json={
+            "ocr_langs": ["eng", "deu"],
+            "min_text_len_for_ocr": 10,
+            "html_crawl_limits": {"max_depth": 3, "max_pages": 5},
+        },
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    resp = client.get(f"/projects/{PROJECT_ID_1}/settings")
+    assert resp.json()["ocr_langs"] == ["eng", "deu"]
+    assert resp.json()["min_text_len_for_ocr"] == 10
+    assert resp.json()["html_crawl_limits"] == {"max_depth": 3, "max_pages": 5}
+
+    html = "<html><body><p>Hello</p></body></html>"
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("test.html", html, "text/html")},
+    )
+    assert resp.status_code == 200
+    doc_id = resp.json()["doc_id"]
+
+    _setup_worker(store, SessionLocal)
+    worker_main.parse_document(doc_id)
+
+    with SessionLocal() as db:
+        ver = db.scalar(
+            select(DocumentVersion).where(DocumentVersion.document_id == doc_id)
+        )
+        assert ver is not None
+        settings_meta = ver.meta.get("parser_settings")
+        assert settings_meta["ocr_langs"] == ["eng", "deu"]
+        assert settings_meta["min_text_len_for_ocr"] == 10
+        assert settings_meta["html_crawl_limits"] == {"max_depth": 3, "max_pages": 5}

--- a/worker/main.py
+++ b/worker/main.py
@@ -22,6 +22,7 @@ from parser_pipeline.metrics import char_coverage
 from parsers import registry
 from storage.object_store import ObjectStore, create_client, raw_key
 from worker.derived_writer import upsert_chunks
+from worker.pipeline import get_parser_settings
 from worker.suggestors import suggest
 
 settings = get_settings()
@@ -142,12 +143,14 @@ def parse_document(doc_id: str, request_id: str | None = None) -> None:
             )
             metrics["utf_other_ratio"] = coverage["other_ratio"]
             meta = dict(ver.meta)
+            project = doc.project
+            parser_settings = get_parser_settings(project)
             parse_meta = dict(meta.get("parse", {}))
             parse_meta["char_coverage_extracted"] = coverage
             meta["parse"] = parse_meta
             meta["metrics"] = metrics
+            meta["parser_settings"] = parser_settings
             ver.meta = meta
-            project = doc.project
             if project.use_rules_suggestor or project.use_mini_llm:
                 total = 0
                 for ch in chunks:

--- a/worker/pipeline.py
+++ b/worker/pipeline.py
@@ -1,0 +1,17 @@
+from core.settings import get_settings
+from models import Project
+
+settings = get_settings()
+
+
+def get_parser_settings(project: Project) -> dict[str, object]:
+    return {
+        "ocr_langs": project.ocr_langs or settings.ocr_langs,
+        "min_text_len_for_ocr": project.min_text_len_for_ocr
+        or settings.min_text_len_for_ocr,
+        "html_crawl_limits": project.html_crawl_limits
+        or {
+            "max_depth": settings.html_crawl_max_depth,
+            "max_pages": settings.html_crawl_max_pages,
+        },
+    }


### PR DESCRIPTION
## Summary
- add ocr_langs, min_text_len_for_ocr, and html_crawl_limits to project settings
- read parser settings at worker task start and store in metadata
- test project setting toggles

## Testing
- `make lint` *(passes)*
- `make lint test` *(fails: coverage command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7463251a0832ba03da05ff69f07f4