### PR TITLE
[C10-13] Observability + queues

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -91,6 +91,7 @@
 | C10-10 | Metrics + gates v2 | codex | ☑ Done | [PR](#) |  |
 | C10-11 | Parser settings wiring | codex | ☑ Done | PR TBD |  |
 | C10-12 | Golden set + scorecard | codex | ☑ Done | [PR](#) |  |
+| C10-13 | Observability + queues | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,27 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.worker
-    command: celery -A worker.main worker --loglevel=info
+    command: celery -A worker.main worker --loglevel=info -Q celery
+    env_file: .env
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A worker.main inspect ping -t 1 > /dev/null"]
+      interval: 10s
+      retries: 5
+    volumes:
+      - .:/app
+
+  worker_ocr:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker
+    command: celery -A worker.main worker --loglevel=info -Q ocr -c 1
     env_file: .env
     depends_on:
       redis:

--- a/tests/test_request_id_and_routing.py
+++ b/tests/test_request_id_and_routing.py
@@ -1,0 +1,18 @@
+from worker import flow
+from worker.celery_app import app
+
+
+def test_request_id_and_ocr_queue() -> None:
+    sig = flow.build_flow("doc1", request_id="rid", do_ocr=True)
+    tasks = sig.tasks
+
+    for idx in [0, 1, 2, 4, 5]:
+        assert tasks[idx].kwargs["request_id"] == "rid"
+
+    ocr_chord = tasks[3]
+    assert ocr_chord.body.kwargs["request_id"] == "rid"
+    for t in ocr_chord.tasks:
+        assert t.kwargs["request_id"] == "rid"
+        assert t.options.get("queue") == "ocr"
+
+    assert app.conf.task_routes["worker.tasks.ocr.ocr_page"]["queue"] == "ocr"

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from celery import Celery  # type: ignore[import-untyped]
+
+from core.settings import get_settings
+
+settings = get_settings()
+
+app = Celery("worker", broker=settings.redis_url)
+app.conf.task_routes = {
+    "worker.tasks.ocr.ocr_page": {"queue": "ocr"},
+}

--- a/worker/flow.py
+++ b/worker/flow.py
@@ -24,7 +24,9 @@ def build_flow(
         cast(Any, extract).s(request_id=request_id),
     ]
     if do_ocr:
-        ocr_group = group(cast(Any, ocr_page).s(doc_id, request_id=request_id))
+        ocr_group = group(
+            cast(Any, ocr_page).s(doc_id, request_id=request_id).set(queue="ocr")
+        )
         steps.append(chord(ocr_group, cast(Any, structure).s(request_id=request_id)))
     else:
         steps.append(cast(Any, structure).s(request_id=request_id))

--- a/worker/main.py
+++ b/worker/main.py
@@ -9,7 +9,6 @@ from urllib.parse import urljoin, urlparse
 import httpx
 import sqlalchemy as sa
 from bs4 import BeautifulSoup, Tag
-from celery import Celery  # type: ignore[import-untyped]
 from sqlalchemy.orm import sessionmaker
 
 from chunking.chunker import chunk_blocks
@@ -21,12 +20,12 @@ from models import Document, DocumentStatus
 from parser_pipeline.metrics import char_coverage
 from parsers import registry
 from storage.object_store import ObjectStore, create_client, raw_key
+from worker.celery_app import app
 from worker.derived_writer import upsert_chunks
 from worker.pipeline import get_parser_settings
 from worker.suggestors import suggest
 
 settings = get_settings()
-app = Celery("worker", broker=settings.redis_url)
 engine = sa.create_engine(settings.database_url)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 

--- a/worker/tasks/chunk_write.py
+++ b/worker/tasks/chunk_write.py
@@ -1,5 +1,6 @@
+from worker.celery_app import app
 from worker.derived_writer import write_chunks
-from worker.main import _get_store, app
+from worker.main import _get_store
 
 from .utils import update_status
 

--- a/worker/tasks/extract.py
+++ b/worker/tasks/extract.py
@@ -1,4 +1,4 @@
-from worker.main import app
+from worker.celery_app import app
 
 from .utils import update_status
 

--- a/worker/tasks/finalize.py
+++ b/worker/tasks/finalize.py
@@ -1,5 +1,5 @@
 from models import DocumentStatus
-from worker.main import app
+from worker.celery_app import app
 
 from .utils import update_status
 

--- a/worker/tasks/normalize.py
+++ b/worker/tasks/normalize.py
@@ -1,4 +1,4 @@
-from worker.main import app
+from worker.celery_app import app
 
 from .utils import update_status
 

--- a/worker/tasks/ocr.py
+++ b/worker/tasks/ocr.py
@@ -1,4 +1,4 @@
-from worker.main import app
+from worker.celery_app import app
 
 from .utils import update_status
 

--- a/worker/tasks/preflight.py
+++ b/worker/tasks/preflight.py
@@ -1,4 +1,4 @@
-from worker.main import app
+from worker.celery_app import app
 
 from .utils import update_status
 

--- a/worker/tasks/structure.py
+++ b/worker/tasks/structure.py
@@ -1,4 +1,4 @@
-from worker.main import app
+from worker.celery_app import app
 
 from .utils import update_status
 


### PR DESCRIPTION
## Summary
- route OCR fan-out tasks to a dedicated `ocr` queue and cap concurrency via compose
- propagate `request_id` through parsing flow and ensure celery routing

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a754bc0810832baadf9db9fdb89820