### PR TITLE
[N30-03] Near-duplicate detection

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -94,6 +94,7 @@
 | C10-13 | Observability + queues | codex | ☑ Done | [PR](#) |  |
 | N30-01 | Incremental re-parse & delta writes | codex | ☑ Done | [PR](#) |  |
 | N30-02 | OCR cache | codex | ☑ Done | [PR](#) |  |
+| N30-03 | Near-duplicate detection | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -857,6 +857,8 @@ def export_jsonl_endpoint(
         taxonomy_version=tax.version,
         filters=payload.filters,
         project=project,
+        drop_near_dupes=payload.drop_near_dupes,
+        dupe_threshold=payload.dupe_threshold,
     )
     return ExportResponse(export_id=export_id, url=url)
 
@@ -886,6 +888,8 @@ def export_csv_endpoint(
         taxonomy_version=tax.version,
         filters=payload.filters,
         project=project,
+        drop_near_dupes=payload.drop_near_dupes,
+        dupe_threshold=payload.dupe_threshold,
     )
     return ExportResponse(export_id=export_id, url=url)
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -122,6 +122,8 @@ class ExportPayload(BaseModel):
     template: str | None = None
     preset: str | None = None
     filters: dict | None = None
+    drop_near_dupes: bool = False
+    dupe_threshold: float = 0.85
 
 
 class ExportResponse(BaseModel):

--- a/core/dedupe.py
+++ b/core/dedupe.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+
+def _simhash(text: str) -> int:
+    """Return 64-bit SimHash for given text."""
+    v = [0] * 64
+    for token in text.split():
+        h = int(hashlib.md5(token.encode("utf-8")).hexdigest(), 16)
+        for i in range(64):
+            v[i] += 1 if h & (1 << i) else -1
+    result = 0
+    for i, val in enumerate(v):
+        if val > 0:
+            result |= 1 << i
+    return result
+
+
+def drop_near_duplicates(
+    chunks: List[dict], threshold: float = 0.85
+) -> Tuple[List[dict], Dict[str, int]]:
+    """Drop near-duplicate chunks using SimHash + LSH.
+
+    Returns filtered chunks and stats {input, dropped, kept}.
+    """
+    if not chunks:
+        return [], {"input": 0, "dropped": 0, "kept": 0}
+    bands = 8
+    rows = 8
+    tables: List[Dict[int, List[int]]] = [defaultdict(list) for _ in range(bands)]
+    max_ham = int(64 * (1 - threshold))
+    kept: List[dict] = []
+    dropped = 0
+    for ch in chunks:
+        text = ch.get("content", {}).get("text", "")
+        sig = _simhash(text)
+        is_dupe = False
+        for b in range(bands):
+            start = b * rows
+            key = (sig >> start) & 0xFF
+            for other in tables[b].get(key, []):
+                if bin(other ^ sig).count("1") <= max_ham:
+                    is_dupe = True
+                    break
+            if is_dupe:
+                break
+        if is_dupe:
+            dropped += 1
+            continue
+        kept.append(ch)
+        for b in range(bands):
+            start = b * rows
+            key = (sig >> start) & 0xFF
+            tables[b][key].append(sig)
+    stats = {"input": len(chunks), "dropped": dropped, "kept": len(kept)}
+    return kept, stats
+
+
+__all__ = ["drop_near_duplicates"]

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,0 +1,57 @@
+import json
+from typing import List
+
+from models import Taxonomy
+from storage.object_store import derived_key, export_key
+from tests.conftest import PROJECT_ID_1
+
+
+def _add_taxonomy(SessionLocal) -> None:
+    with SessionLocal() as session:
+        session.add(Taxonomy(project_id=PROJECT_ID_1, version=1, fields=[]))
+        session.commit()
+
+
+def _put_chunk(store, doc_id: str, text: str, section: List[str]) -> None:
+    chunk = {
+        "doc_id": doc_id,
+        "chunk_id": f"{doc_id}-c1",
+        "order": 0,
+        "rev": 1,
+        "content": {"type": "text", "text": text},
+        "source": {"page": 1, "section_path": section},
+        "text_hash": "h",
+        "metadata": {},
+    }
+    store.put_bytes(
+        derived_key(doc_id, "chunks.jsonl"),
+        (json.dumps(chunk) + "\n").encode("utf-8"),
+    )
+
+
+def test_drop_near_duplicates(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    _add_taxonomy(SessionLocal)
+    _put_chunk(store, "d1", "alpha", ["A"])
+    _put_chunk(store, "d2", "alpha", ["B"])
+    _put_chunk(store, "d3", "beta", ["C"])
+    template = '{{ {"text": chunk.content.text} | tojson }}'
+    resp = client.post(
+        "/export/jsonl",
+        json={
+            "project_id": str(PROJECT_ID_1),
+            "doc_ids": ["d1", "d2", "d3"],
+            "template": template,
+            "drop_near_dupes": True,
+        },
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    key = export_key(data["export_id"], "data.jsonl")
+    lines = store.get_bytes(key).decode("utf-8").strip().splitlines()
+    assert len(lines) == 2
+    manifest = json.loads(
+        store.get_bytes(export_key(data["export_id"], "manifest.json")).decode("utf-8")
+    )
+    assert manifest["drop_stats"]["near_duplicates"]["dropped"] == 1


### PR DESCRIPTION
## Summary
- add SimHash-based near-duplicate detection with LSH
- allow exporters to drop similar chunks and record drop stats
- expose drop_near_dupes option on export endpoints

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*
- `pytest tests/test_dedupe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8009edf64832bb015668148c31355