### PR TITLE
feature/N30-04-active-learning

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -95,6 +95,7 @@
 | N30-01 | Incremental re-parse & delta writes | codex | ☑ Done | [PR](#) |  |
 | N30-02 | OCR cache | codex | ☑ Done | [PR](#) |  |
 | N30-03 | Near-duplicate detection | codex | ☑ Done | [PR](#) |  |
+| N30-04 | Active learning queue | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -141,3 +141,8 @@ class CrawlPayload(BaseModel):
     allow_prefix: str | None = None
     max_depth: int
     max_pages: int
+
+
+class ActiveLearningEntry(BaseModel):
+    chunk_id: str
+    reasons: List[str]

--- a/core/active_learning.py
+++ b/core/active_learning.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.metrics import _required_fields
+from core.settings import get_settings
+from models import Chunk, Document
+
+settings = get_settings()
+
+
+def _has_value(meta: dict, field: str) -> bool:
+    if field not in meta:
+        return False
+    value = meta[field]
+    if value is None:
+        return False
+    if isinstance(value, str) and value.strip() == "":
+        return False
+    return True
+
+
+def score_chunk(chunk: Chunk, required: List[str]) -> List[str]:
+    reasons: List[str] = []
+    meta = chunk.meta or {}
+    text_cov = meta.get("text_coverage")
+    if text_cov is not None and text_cov < settings.text_coverage_threshold:
+        reasons.append("low_text_coverage")
+    ocr_conf = meta.get("ocr_conf_mean")
+    if ocr_conf is not None and ocr_conf < 0.5:
+        reasons.append("low_ocr_conf")
+    if any(not _has_value(meta, f) for f in required):
+        reasons.append("missing_required_fields")
+    suggestions = meta.get("suggestions", {})
+    for field, info in suggestions.items():
+        if field in meta and meta[field] != info.get("value"):
+            reasons.append("suggestion_conflicts")
+            break
+    return reasons
+
+
+def next_chunks(
+    project_id: str | uuid.UUID, limit: int, db: Session
+) -> List[tuple[str, List[str]]]:
+    if limit < 1:
+        return []
+    if isinstance(project_id, str):
+        project_id = uuid.UUID(project_id)
+    required = _required_fields(project_id, db)
+    stmt = (
+        select(Chunk)
+        .join(Document, Chunk.document_id == Document.id)
+        .where(Document.project_id == project_id)
+        .order_by(Chunk.created_at)
+        .limit(limit * 5)
+    )
+    chunks = db.scalars(stmt)
+    entries: List[tuple[str, List[str]]] = []
+    for ch in chunks:
+        reasons = score_chunk(ch, required)
+        if reasons:
+            entries.append((ch.id, reasons))
+        if len(entries) >= limit:
+            break
+    return entries

--- a/tests/test_active_learning_queue.py
+++ b/tests/test_active_learning_queue.py
@@ -1,0 +1,85 @@
+import uuid
+
+from models import Chunk, Document, DocumentStatus, DocumentVersion, Taxonomy
+from tests.conftest import PROJECT_ID_1
+
+
+def setup(SessionLocal) -> dict[str, str]:
+    with SessionLocal() as db:
+        doc_id = str(uuid.uuid4())
+        dv_id = str(uuid.uuid4())
+        c1 = str(uuid.uuid4())
+        c2 = str(uuid.uuid4())
+        c3 = str(uuid.uuid4())
+        doc = Document(
+            id=doc_id,
+            project_id=PROJECT_ID_1,
+            source_type="pdf",
+            latest_version_id=dv_id,
+        )
+        dv = DocumentVersion(
+            id=dv_id,
+            document_id=doc_id,
+            project_id=PROJECT_ID_1,
+            version=1,
+            doc_hash="h",
+            mime="text/plain",
+            size=1,
+            status=DocumentStatus.PARSED.value,
+            meta={},
+        )
+        chunk1 = Chunk(
+            id=c1,
+            document_id=doc_id,
+            version=1,
+            order=1,
+            content={},
+            text_hash="t1",
+            meta={"text_coverage": 0.2},
+        )
+        chunk2 = Chunk(
+            id=c2,
+            document_id=doc_id,
+            version=1,
+            order=2,
+            content={},
+            text_hash="t2",
+            meta={
+                "suggestions": {"severity": {"value": "ERROR"}},
+                "severity": "INFO",
+            },
+        )
+        chunk3 = Chunk(
+            id=c3,
+            document_id=doc_id,
+            version=1,
+            order=3,
+            content={},
+            text_hash="t3",
+            meta={"ocr_conf_mean": 0.3},
+        )
+        tax = Taxonomy(
+            project_id=PROJECT_ID_1,
+            version=1,
+            fields=[{"name": "severity", "type": "enum", "required": True}],
+        )
+        db.add_all([doc, dv, chunk1, chunk2, chunk3, tax])
+        db.commit()
+        return {"c1": c1, "c2": c2, "c3": c3}
+
+
+def test_active_learning_queue(test_app) -> None:
+    client, _, _, SessionLocal = test_app
+    ids = setup(SessionLocal)
+    resp = client.get(
+        f"/curation/next?project_id={PROJECT_ID_1}&limit=2",
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {
+            "chunk_id": ids["c1"],
+            "reasons": ["low_text_coverage", "missing_required_fields"],
+        },
+        {"chunk_id": ids["c2"], "reasons": ["suggestion_conflicts"]},
+    ]


### PR DESCRIPTION
## Summary
- add ActiveLearningEntry schema and scoring utilities for chunk prioritization
- expose GET /curation/next to return chunk IDs with reasons
- document progress in STATUS.md

## Testing
- `make lint`
- `make test` *(fails: coverage command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a80374bb20832b8238547bf4033319