### PR TITLE
feature/N30-08-tenancy

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -99,6 +99,7 @@
 | N30-05 | IAA & conflicts | codex | ☑ Done | [PR](#) |  |
 | N30-06 | Taxonomy migrations | codex | ☑ Done | [PR](#) |  |
 | N30-07 | PII detection & redaction | codex | ☑ Done | [PR](#) |  |
+| N30-08 | Tenancy hardening | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/core/security/project_scope.py
+++ b/core/security/project_scope.py
@@ -1,0 +1,35 @@
+import uuid
+
+from fastapi import Header, HTTPException
+from sqlalchemy.orm import Session
+
+from models import Document
+
+
+def get_project_scope(
+    x_project_id: str | None = Header(default=None),
+) -> uuid.UUID | None:
+    """Return project UUID from header if provided."""
+    if x_project_id is None:
+        return None
+    try:
+        return uuid.UUID(x_project_id)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="invalid project scope") from exc
+
+
+def ensure_document_scope(
+    doc_id: str,
+    db: Session,
+    project_id: uuid.UUID | None,
+) -> Document:
+    """Fetch document and verify it belongs to scoped project."""
+    doc = db.get(Document, doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="document not found")
+    if project_id and doc.project_id != project_id:
+        raise HTTPException(status_code=403, detail="forbidden")
+    return doc
+
+
+__all__ = ["get_project_scope", "ensure_document_scope"]

--- a/tests/test_project_tenancy.py
+++ b/tests/test_project_tenancy.py
@@ -1,0 +1,47 @@
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from storage.object_store import derived_key, signed_url
+from tests.conftest import PROJECT_ID_1, PROJECT_ID_2
+
+
+def _ingest(client, project_id: uuid.UUID) -> str:
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(project_id)},
+        files={"file": ("f.txt", b"data", "text/plain")},
+    )
+    assert resp.status_code == 200
+    return resp.json()["doc_id"]
+
+
+def test_document_access_scoped(test_app) -> None:
+    client, _, _, _ = test_app
+    doc1 = _ingest(client, PROJECT_ID_1)
+    doc2 = _ingest(client, PROJECT_ID_2)
+
+    resp_ok = client.get(
+        f"/documents/{doc1}", headers={"X-Project-ID": str(PROJECT_ID_1)}
+    )
+    assert resp_ok.status_code == 200
+
+    resp_forbidden = client.get(
+        f"/documents/{doc2}", headers={"X-Project-ID": str(PROJECT_ID_1)}
+    )
+    assert resp_forbidden.status_code == 403
+
+
+def test_presigned_url_scoped(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    doc1 = _ingest(client, PROJECT_ID_1)
+    with SessionLocal() as db:
+        with pytest.raises(HTTPException) as exc:
+            signed_url(
+                store,
+                derived_key(doc1, "chunks.jsonl"),
+                db=db,
+                project_id=str(PROJECT_ID_2),
+            )
+        assert exc.value.status_code == 403


### PR DESCRIPTION
## Summary
- enforce project scoping on ingest, document, chunk, and export endpoints
- add optional project checks to object-store signed URL helper
- guard document access with new project scope utilities

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*
- `pytest tests/test_project_tenancy.py`

------
https://chatgpt.com/codex/tasks/task_e_68a81ff3405c832b9c508eb334bf9b9e