### PR TITLE
feature/N30-10-splits

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -101,6 +101,7 @@
 | N30-07 | PII detection & redaction | codex | ☑ Done | [PR](#) |  |
 | N30-08 | Tenancy hardening | codex | ☑ Done | [PR](#) |  |
 | N30-09 | HF/Parquet exporters | codex | ☑ Done | [PR](#) |  |
+| N30-10 | Stratified splits | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -936,6 +936,7 @@ def export_jsonl_endpoint(
         drop_near_dupes=payload.drop_near_dupes,
         dupe_threshold=payload.dupe_threshold,
         exclude_pii=payload.exclude_pii,
+        split=payload.split,
     )
     return ExportResponse(export_id=export_id, url=url)
 
@@ -975,6 +976,7 @@ def export_csv_endpoint(
         drop_near_dupes=payload.drop_near_dupes,
         dupe_threshold=payload.dupe_threshold,
         exclude_pii=payload.exclude_pii,
+        split=payload.split,
     )
     return ExportResponse(export_id=export_id, url=url)
 
@@ -1014,6 +1016,7 @@ def export_parquet_endpoint(
         drop_near_dupes=payload.drop_near_dupes,
         dupe_threshold=payload.dupe_threshold,
         exclude_pii=payload.exclude_pii,
+        split=payload.split,
     )
     return ExportResponse(export_id=export_id, url=url)
 
@@ -1053,6 +1056,7 @@ def export_hf_endpoint(
         drop_near_dupes=payload.drop_near_dupes,
         dupe_threshold=payload.dupe_threshold,
         exclude_pii=payload.exclude_pii,
+        split=payload.split,
     )
     return ExportResponse(export_id=export_id, url=url)
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -133,6 +133,7 @@ class ExportPayload(BaseModel):
     drop_near_dupes: bool = False
     dupe_threshold: float = 0.85
     exclude_pii: bool = True
+    split: dict | None = None
 
 
 class ExportResponse(BaseModel):

--- a/exporters/splitter.py
+++ b/exporters/splitter.py
@@ -1,0 +1,45 @@
+import random
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+
+def apply_split(chunks: List[dict], spec: Dict) -> Tuple[List[dict], Dict[str, int]]:
+    strategy = spec.get("strategy")
+    if strategy != "stratified":
+        raise ValueError("unsupported split strategy")
+    by = spec.get("by") or []
+    seed = spec.get("seed")
+    fractions = spec.get("fractions", {"train": 0.8, "test": 0.2})
+    rnd = random.Random(seed)
+    docs: Dict[str, List[dict]] = defaultdict(list)
+    meta_vals: Dict[str, Tuple] = {}
+    for ch in chunks:
+        docs[ch["doc_id"]].append(ch)
+        meta = ch.get("metadata", {})
+        key = tuple(meta.get(f) for f in by)
+        meta_vals[ch["doc_id"]] = key
+    groups: Dict[Tuple, List[str]] = defaultdict(list)
+    for doc_id, key in meta_vals.items():
+        groups[key].append(doc_id)
+    doc_split: Dict[str, str] = {}
+    for key, doc_ids in groups.items():
+        rnd.shuffle(doc_ids)
+        n = len(doc_ids)
+        items = list(fractions.items())
+        start = 0
+        for i, (name, frac) in enumerate(items):
+            count = int(round(frac * n))
+            if i == len(items) - 1:
+                count = n - start
+            for doc_id in doc_ids[start : start + count]:
+                doc_split[doc_id] = name
+            start += count
+    counts = {name: 0 for name in fractions.keys()}
+    default_split = next(iter(fractions.keys()))
+    for doc_id, chs in docs.items():
+        split_name = doc_split.get(doc_id, default_split)
+        for ch in chs:
+            meta = ch.setdefault("metadata", {})
+            meta["split"] = split_name
+            counts[split_name] += 1
+    return chunks, counts

--- a/tests/test_stratified_split.py
+++ b/tests/test_stratified_split.py
@@ -1,0 +1,80 @@
+import json
+from typing import List
+
+from models import Document, Taxonomy
+from storage.object_store import derived_key, export_key
+from tests.conftest import PROJECT_ID_1
+
+
+def _add_taxonomy(SessionLocal) -> None:
+    with SessionLocal() as session:
+        session.add(Taxonomy(project_id=PROJECT_ID_1, version=1, fields=[]))
+        session.commit()
+
+
+def _put_doc(store, session, doc_id: str, severity: str, texts: List[str]) -> None:
+    session.add(Document(id=doc_id, project_id=PROJECT_ID_1, source_type="pdf"))
+    lines = []
+    for idx, text in enumerate(texts):
+        chunk = {
+            "doc_id": doc_id,
+            "chunk_id": f"{doc_id}-c{idx}",
+            "order": idx,
+            "rev": 1,
+            "content": {"type": "text", "text": text},
+            "source": {"page": 1, "section_path": ["S"]},
+            "text_hash": "h",
+            "metadata": {"severity": severity},
+        }
+        lines.append(json.dumps(chunk))
+    store.put_bytes(
+        derived_key(doc_id, "chunks.jsonl"),
+        ("\n".join(lines) + "\n").encode("utf-8"),
+    )
+
+
+def test_stratified_split(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    _add_taxonomy(SessionLocal)
+    with SessionLocal() as session:
+        _put_doc(store, session, "d1", "high", ["a", "b"])
+        _put_doc(store, session, "d2", "high", ["c", "d"])
+        _put_doc(store, session, "d3", "low", ["e", "f"])
+        _put_doc(store, session, "d4", "low", ["g", "h"])
+        session.commit()
+    template = '{{ {"doc_id": chunk.doc_id, "split": chunk.metadata.split} | tojson }}'
+    resp = client.post(
+        "/export/jsonl",
+        json={
+            "project_id": str(PROJECT_ID_1),
+            "doc_ids": ["d1", "d2", "d3", "d4"],
+            "template": template,
+            "split": {
+                "strategy": "stratified",
+                "by": ["severity"],
+                "fractions": {"train": 0.5, "test": 0.5},
+                "seed": 42,
+            },
+        },
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    key = export_key(data["export_id"], "data.jsonl")
+    lines = store.get_bytes(key).decode("utf-8").strip().splitlines()
+    parsed = [json.loads(l) for l in lines]
+    doc_splits = {}
+    for row in parsed:
+        doc_splits.setdefault(row["doc_id"], row["split"])
+        assert doc_splits[row["doc_id"]] == row["split"]
+    # each severity should appear once per split
+    sev_map = {"d1": "high", "d2": "high", "d3": "low", "d4": "low"}
+    counts = {"high": {"train": 0, "test": 0}, "low": {"train": 0, "test": 0}}
+    for doc_id, split in doc_splits.items():
+        counts[sev_map[doc_id]][split] += 1
+    assert counts["high"] == {"train": 1, "test": 1}
+    assert counts["low"] == {"train": 1, "test": 1}
+    manifest = json.loads(
+        store.get_bytes(export_key(data["export_id"], "manifest.json")).decode("utf-8")
+    )
+    assert manifest["split_stats"] == {"train": 4, "test": 4}


### PR DESCRIPTION
## Summary
- add stratified splitter with seeded randomness and doc-level grouping
- allow exporters to accept `split` param and record split stats in manifest
- test stratified split behavior

## Testing
- `make lint`
- `make test` *(fails: coverage: command not found)*
- `pytest tests/test_stratified_split.py`


------
https://chatgpt.com/codex/tasks/task_e_68a824c7f400832b91dcfb8641f05b6b