### PR TITLE
feature/N30-12-multilingual-ocr

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -103,6 +103,7 @@
 | N30-09 | HF/Parquet exporters | codex | ☑ Done | [PR](#) |  |
 | N30-10 | Stratified splits | codex | ☑ Done | [PR](#) |  |
 | N30-11 | Tables v1 (texty) | codex | ☑ Done | [PR](#) |  |
+| N30-12 | Multilingual OCR & language detection | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ charset-normalizer
 lxml
 pyarrow
 datasets
+langdetect

--- a/tests/test_manifest_v2.py
+++ b/tests/test_manifest_v2.py
@@ -45,6 +45,8 @@ def test_manifest_v2_fields_and_presign(test_app):
     assert manifest["stage_metrics"]["empty_chunk_ratio"] == 0.5
     assert manifest["files"] == ["a.html"]
     assert manifest["pages_ocr"] == [2]
+    assert manifest["langs_used"] == []
+    assert manifest["page_langs"] == []
     assert "created_at" in manifest
     assert "X-Amz-Expires" in chunks_url
     assert "X-Amz-Expires" in manifest_url

--- a/tests/test_multilingual_ocr.py
+++ b/tests/test_multilingual_ocr.py
@@ -1,0 +1,72 @@
+import io
+import json
+import uuid
+
+import pytest
+from PIL import Image, ImageDraw
+
+pytest.importorskip("fitz")
+pytest.importorskip("pytesseract")
+pytest.importorskip("langdetect")
+
+import fitz  # type: ignore[import-not-found, import-untyped]
+import pytesseract  # type: ignore[import-untyped]
+
+from chunking.chunker import Block as ChunkBlock
+from chunking.chunker import chunk_blocks
+from parsers.pdf_v2 import PDFParserV2
+from storage.object_store import derived_key
+from worker.derived_writer import upsert_chunks
+
+
+def _tesseract_available() -> bool:
+    try:
+        pytesseract.get_tesseract_version()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _tesseract_available(), reason="tesseract not installed")
+def test_multilingual_ocr_manifest(test_app) -> None:
+    doc = fitz.open()
+
+    page1 = doc.new_page()
+    page1.insert_text((72, 72), "HELLO world")
+
+    page2 = doc.new_page()
+    img = Image.new("RGB", (300, 40), "white")
+    draw = ImageDraw.Draw(img)
+    draw.text((5, 5), "HALLO WELT HALLO WELT", fill="black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    page2.insert_image(fitz.Rect(0, 0, 300, 40), stream=buf.getvalue())
+
+    pdf_bytes = doc.tobytes()
+    doc.close()
+
+    parser = PDFParserV2(langs=["eng", "deu"])
+    blocks = list(parser.parse(pdf_bytes))
+
+    assert parser.page_metrics[0].lang == "en"
+    assert parser.page_metrics[1].lang == "de"
+    assert parser.langs_used == ["de", "en"]
+
+    cb_blocks = []
+    for b in blocks:
+        meta = {}
+        if "lang" in b.meta:
+            meta["lang"] = b.meta["lang"]
+        if "source_stage" in b.meta:
+            meta["source_stage"] = b.meta["source_stage"]
+        cb_blocks.append(ChunkBlock(text=b.text, page=b.meta["page"], metadata=meta))
+    chunks = chunk_blocks(cb_blocks)
+
+    _, store, _, SessionLocal = test_app
+    with SessionLocal() as db:
+        doc_id = str(uuid.uuid4())
+        upsert_chunks(db, store, doc_id=doc_id, version=1, chunks=chunks)
+
+    manifest = json.loads(store.client.store[derived_key(doc_id, "manifest.json")])
+    assert manifest["page_langs"] == ["en", "de"]
+    assert manifest["langs_used"] == ["de", "en"]

--- a/tests/test_pdf_v2_ocr.py
+++ b/tests/test_pdf_v2_ocr.py
@@ -37,7 +37,7 @@ def test_pdf_v2_ocr() -> None:
     pdf_bytes = doc.tobytes()
     doc.close()
 
-    parser = PDFParserV2(lang="eng")
+    parser = PDFParserV2(langs=["eng"])
     blocks = list(parser.parse(pdf_bytes))
 
     assert any(b.meta["source_stage"] == "pdf_text" for b in blocks)


### PR DESCRIPTION
## Summary
- add optional language detection to PDF parser with per-page metrics and multi-language Tesseract configuration
- record detected languages in document manifest and expose overall/lang-by-page fields
- test multilingual OCR pipeline and manifest output

## Testing
- `make lint`
- `make test` *(fails: coverage command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a83f5f701c832b8392219b3c3c2f7c