### PR TITLE
[F40-02] Figures & captions + image-block OCR

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -106,6 +106,7 @@
 | N30-12 | Multilingual OCR & language detection | codex | ☑ Done | [PR](#) |  |
 | N30-13 | Metrics & dashboards | codex | ☑ Done | [PR](#) |  |
 | F40-01 | Tables v1.5 (structured) | codex | ☑ Done | [PR](#) |  |
+| F40-02 | Figures & captions + image-block OCR | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/parsers/html_figures.py
+++ b/parsers/html_figures.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from bs4 import BeautifulSoup
+
+
+@dataclass
+class HTMLFigure:
+    src: str
+    caption: str | None
+
+
+def extract_figures(html: str) -> List[HTMLFigure]:
+    """Return figures with image source and caption text.
+
+    Only <figure> tags containing an <img> are considered. The caption is taken
+    from a nested <figcaption> if present.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    figures: List[HTMLFigure] = []
+    for fig in soup.find_all("figure"):
+        img = fig.find("img")
+        if img is None:
+            continue
+        src = img.get("src", "")
+        caption_tag = fig.find("figcaption")
+        caption = caption_tag.get_text(" ", strip=True) if caption_tag else None
+        figures.append(HTMLFigure(src=src, caption=caption))
+    return figures
+
+
+__all__ = ["HTMLFigure", "extract_figures"]

--- a/parsers/pdf_figures.py
+++ b/parsers/pdf_figures.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import fitz  # type: ignore[import-not-found, import-untyped]
+
+from storage.object_store import ObjectStore, figure_key, signed_url
+
+
+@dataclass
+class PDFFigure:
+    page: int
+    image_key: str
+    image_url: str
+    caption: str | None
+
+
+def extract_figures(
+    pdf_bytes: bytes, *, store: ObjectStore, doc_id: str
+) -> List[PDFFigure]:
+    """Detect image blocks and nearby captions.
+
+    For each image block, the image bytes are saved to the object store under a
+    derived figures path. A presigned URL is returned along with a simple
+    caption guess: the text of the next block if it is a text block.
+    """
+    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    figures: List[PDFFigure] = []
+    for page_index, page in enumerate(doc):
+        blocks = page.get_text("dict").get("blocks", [])
+        for i, block in enumerate(blocks):
+            if block.get("type") != 1:
+                continue
+            img_bytes = block.get("image")
+            if not isinstance(img_bytes, bytes):
+                continue
+            key = figure_key(doc_id, f"page{page_index}_img{i}.png")
+            store.put_bytes(key, img_bytes)
+            url = signed_url(store, key)
+            caption: str | None = None
+            for j in range(i + 1, len(blocks)):
+                nb = blocks[j]
+                if nb.get("type") == 0:
+                    caption_lines = [
+                        span["text"]
+                        for line in nb.get("lines", [])
+                        for span in line.get("spans", [])
+                    ]
+                    caption = "".join(caption_lines).strip() or None
+                    break
+            figures.append(
+                PDFFigure(
+                    page=page_index, image_key=key, image_url=url, caption=caption
+                )
+            )
+    doc.close()
+    return figures
+
+
+__all__ = ["PDFFigure", "extract_figures"]

--- a/storage/object_store.py
+++ b/storage/object_store.py
@@ -12,6 +12,7 @@ from models import Document
 RAW_PREFIX = "raw"
 DERIVED_PREFIX = "derived"
 EXPORTS_PREFIX = "exports"
+FIGURES_SUBPATH = "figures"
 
 
 def raw_key(doc_id: str, filename: str) -> str:
@@ -24,6 +25,11 @@ def raw_bundle_key(doc_id: str) -> str:
 
 def derived_key(doc_id: str, filename: str) -> str:
     return f"{DERIVED_PREFIX}/{doc_id}/{filename}"
+
+
+def figure_key(doc_id: str, filename: str) -> str:
+    """Location for derived figure images."""
+    return derived_key(doc_id, f"{FIGURES_SUBPATH}/{filename}")
 
 
 def export_key(export_id: str, filename: str) -> str:
@@ -99,6 +105,7 @@ __all__ = [
     "raw_key",
     "raw_bundle_key",
     "derived_key",
+    "figure_key",
     "export_key",
     "signed_url",
 ]

--- a/tests/test_figures_and_captions.py
+++ b/tests/test_figures_and_captions.py
@@ -1,0 +1,90 @@
+import base64
+import io
+
+import pytest
+
+pytest.importorskip("fitz")
+pytest.importorskip("pytesseract")
+
+import fitz  # type: ignore[import-not-found, import-untyped]
+import pytesseract  # type: ignore[import-untyped]
+
+from parsers.html_figures import extract_figures as extract_html_figures
+from parsers.pdf_figures import extract_figures as extract_pdf_figures
+from storage.object_store import ObjectStore
+from worker.ocr.image_block import ocr_image_block
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    def put_object(self, Bucket: str, Key: str, Body: bytes) -> None:  # noqa: N803
+        self.store[Key] = Body
+
+    def get_object(self, Bucket: str, Key: str) -> dict:  # noqa: N803
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def list_objects_v2(self, Bucket: str, Prefix: str) -> dict:  # noqa: N803
+        keys = [k for k in self.store if k.startswith(Prefix)]
+        return {"Contents": [{"Key": k} for k in keys]}
+
+    def generate_presigned_url(
+        self, operation: str, Params: dict, ExpiresIn: int
+    ) -> str:  # noqa: N803
+        return f"https://example.com/{Params['Key']}?X-Amz-Expires={ExpiresIn}"
+
+
+HTML_SNIPPET = """
+<figure>
+  <img src="img.png" />
+  <figcaption>An example figure</figcaption>
+</figure>
+"""
+
+IMAGE_PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAGQAAAAoCAIAAACHGsgUAAAB+UlEQVR4nO3Yv6uyUBjA8YyXgpYg"
+    "qMH2gqJFpziDmuLSFASNTY3N/SVNDdUS/QVhP4YarE1CCILG2m3KMPLcQa5c3vcle6Dw3svzmfR0i"
+    "sO3ziFkKKUR9Jxo2Av4STAWAMYCwFgAGAsAYwFgLACMBYCxADAWAMYCCI7V7/d5ni+XyzzPD4dDb7DX63Ec"
+    "JwhCtVo9Ho/eYCKREEVREASO41ar1RtXHRb6kKZphBDLsiillmURQubz+Ww2kyTpcrlQSieTSaVS8SYnk0nvwjTNUqn0+JN/ooBYsiyv12v/Vtd1RVFUVd1sNv5gq9Vy"
+    "HId+ieW6biqVev1iwxYQi2VZ27b9W9u2WZbNZrPX6/XfyX4sTdPq9frrFvld/IHuWYZh7vf7f191HEcUxdvttt/vd7vdKw6J7yXggC8UCoZh+LeGYRSLxVwut91uvRFK"
+    "abPZ9K5jsdhyudR1vdPpDAaDt6w3XI9/eNPplBByPp/p5wG/WCzG47GiKN5OHI1GjUbDm+xvQ8MwarXa23ZDaAK2oaqqp9NJkqR4PO44TrvdlmU5EokcDgee59PpdCaT"
+    "6Xa7f70rn8+bpum6bjT6q/7HMRSfwT/tV33z74axADAWAMYCwFgAGAsAYwFgLACMBYCxADAWAMYCwFgAGAsAYwFgLACMBYCxADAWwAeEQLqnJKe0wQAAAABJRU5ErkJggg=="
+)
+
+
+def test_html_figure_extraction() -> None:
+    figs = extract_html_figures(HTML_SNIPPET)
+    assert len(figs) == 1
+    assert figs[0].src == "img.png"
+    assert figs[0].caption == "An example figure"
+
+
+def _tesseract_available() -> bool:
+    try:
+        pytesseract.get_tesseract_version()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _tesseract_available(), reason="tesseract not installed")
+def test_pdf_figures_and_ocr() -> None:
+    client = FakeS3Client()
+    store = ObjectStore(client=client, bucket="test")
+    doc = fitz.open()
+    page = doc.new_page()
+    image_bytes = base64.b64decode(IMAGE_PNG_BASE64)
+    page.insert_image(fitz.Rect(0, 0, 100, 40), stream=image_bytes)
+    page.insert_text((0, 50), "Figure: Greeting")
+    pdf_bytes = doc.tobytes()
+    doc.close()
+
+    figures = extract_pdf_figures(pdf_bytes, store=store, doc_id="doc1")
+    assert figures
+    fig = figures[0]
+    assert fig.caption == "Figure: Greeting"
+    assert fig.image_key in client.store
+    ocr_text, conf = ocr_image_block(client.store[fig.image_key])
+    assert "HELLO" in ocr_text
+    assert conf > 0

--- a/worker/ocr/image_block.py
+++ b/worker/ocr/image_block.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Tuple
+
+import pytesseract  # type: ignore[import-untyped]
+from PIL import Image  # type: ignore[import-untyped]
+
+
+def ocr_image_block(image_bytes: bytes, *, langs: str = "eng") -> Tuple[str, float]:
+    """OCR text from an image block and return text and mean confidence."""
+    image = Image.open(BytesIO(image_bytes))
+    data = pytesseract.image_to_data(
+        image, lang=langs, output_type=pytesseract.Output.DICT
+    )
+    text = " ".join(data.get("text", [])).strip()
+    confs = [float(c) for c in data.get("conf", []) if c != "-1"]
+    conf_mean = sum(confs) / len(confs) if confs else 0.0
+    return text, conf_mean
+
+
+__all__ = ["ocr_image_block"]


### PR DESCRIPTION
## Summary
- detect HTML `<figure>` blocks and capture captions
- parse PDF image blocks, store crops in object store with presigned URLs and captions
- add OCR utility for image blocks

## Testing
- `make lint`
- `make test` *(fails: coverage command not found)*
- `pytest tests/test_figures_and_captions.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9d403abdc832baafa75c98b1628c4