### PR TITLE
[F40-03] Layout-aware chunking

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -107,6 +107,7 @@
 | N30-13 | Metrics & dashboards | codex | ☑ Done | [PR](#) |  |
 | F40-01 | Tables v1.5 (structured) | codex | ☑ Done | [PR](#) |  |
 | F40-02 | Figures & captions + image-block OCR | codex | ☑ Done | [PR](#) |  |
+| F40-03 | Layout-aware chunking | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/exporters/common.py
+++ b/exporters/common.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class ExportChunk:
+    """Lightweight chunk model used by exporters.
+
+    Step information, when available, is stored in ``metadata['step_id']``
+    and exposed via the :attr:`step_id` property.
+    """
+
+    doc_id: str
+    chunk_id: str
+    order: int
+    content: Dict[str, Any]
+    source: Dict[str, Any]
+    text_hash: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def step_id(self) -> Optional[int]:
+        return self.metadata.get("step_id")
+
+
+__all__ = ["ExportChunk"]

--- a/parsers/html_figures.py
+++ b/parsers/html_figures.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 
 @dataclass
@@ -21,12 +21,18 @@ def extract_figures(html: str) -> List[HTMLFigure]:
     soup = BeautifulSoup(html, "html.parser")
     figures: List[HTMLFigure] = []
     for fig in soup.find_all("figure"):
-        img = fig.find("img")
-        if img is None:
+        if not isinstance(fig, Tag):
             continue
-        src = img.get("src", "")
+        img = fig.find("img")
+        if not isinstance(img, Tag):
+            continue
+        src = str(img.get("src") or "")
         caption_tag = fig.find("figcaption")
-        caption = caption_tag.get_text(" ", strip=True) if caption_tag else None
+        caption = (
+            caption_tag.get_text(" ", strip=True)
+            if isinstance(caption_tag, Tag)
+            else None
+        )
         figures.append(HTMLFigure(src=src, caption=caption))
     return figures
 

--- a/tests/test_layout_chunking.py
+++ b/tests/test_layout_chunking.py
@@ -1,0 +1,52 @@
+from chunking.chunker_v2 import Block, chunk_blocks
+from exporters.common import ExportChunk
+from parser_pipeline.structure import structure
+
+
+def test_structure_html_list_detects_steps() -> None:
+    html = "<h1>Proc</h1><ol><li>First</li><li>Second</li></ol>"
+    blocks = list(structure(html.encode("utf-8"), source_type="text/html"))
+    kinds = [b.metadata.get("kind") for b in blocks]
+    assert kinds == ["title", "step", "step"]
+
+
+def test_chunker_step_ids_and_sections() -> None:
+    blocks = [
+        Block(text="Intro", file_path="a", page=1, section_path=["Proc"]),
+        Block(
+            text="Step 1: Do X",
+            file_path="a",
+            page=1,
+            section_path=["Proc"],
+            metadata={"kind": "step"},
+        ),
+        Block(
+            text="More details",
+            file_path="a",
+            page=1,
+            section_path=["Proc"],
+        ),
+        Block(
+            text="Step 2: Do Y",
+            file_path="a",
+            page=1,
+            section_path=["Proc"],
+            metadata={"kind": "step"},
+        ),
+    ]
+    chunks = chunk_blocks(blocks, max_tokens=50)
+    assert [c.metadata.get("step_id") for c in chunks] == [None, 1, 2]
+    assert chunks[1].metadata["section_path"] == ["Proc"]
+    ec = ExportChunk(
+        doc_id="d",
+        chunk_id=str(chunks[1].id),
+        order=chunks[1].order,
+        content={"type": chunks[1].content.type, "text": chunks[1].content.text},
+        source={
+            "page": chunks[1].metadata.get("page"),
+            "section_path": chunks[1].metadata["section_path"],
+        },
+        text_hash=chunks[1].text_hash,
+        metadata=chunks[1].metadata,
+    )
+    assert ec.step_id == 1


### PR DESCRIPTION
## Summary
- Detect procedural steps in HTML and PDF structure parsing.
- Split chunks at step boundaries, attach incremental `step_id`, and export through a lightweight `ExportChunk` model.
- Verify step-aware chunking logic with new tests and docs update.

## Testing
- `make lint`
- `pytest tests/test_layout_chunking.py`
- `make test` *(fails: coverage command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d7a1bf60832bacb81219e637ed65