### PR TITLE
[F40-07] Stratified & balanced splits

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -111,6 +111,7 @@
 | F40-04 | Curation Lite UI | codex | ☑ Done | [PR](#) |  |
 | F40-05 | Dataset releases & snapshotting | codex | ☑ Done | [PR](#) |  |
 | F40-06 | Active-learning triage board | codex | ☑ Done | [PR](#) |  |
+| F40-07 | Stratified & balanced splits | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -122,7 +122,7 @@ def _compute_export_id(
             "use_mini_llm": project.use_mini_llm,
             "max_suggestions_per_doc": project.max_suggestions_per_doc,
             "suggestion_timeout_ms": project.suggestion_timeout_ms,
-            "tables_as_text": project.tables_as_text,
+            "tables_as_text": getattr(project, "tables_as_text", False),
         }
     payload = json.dumps(payload_dict, sort_keys=True)
     return (
@@ -172,7 +172,7 @@ def _write_manifest(
                 "use_mini_llm": project.use_mini_llm,
                 "max_suggestions_per_doc": project.max_suggestions_per_doc,
                 "suggestion_timeout_ms": project.suggestion_timeout_ms,
-                "tables_as_text": project.tables_as_text,
+                "tables_as_text": getattr(project, "tables_as_text", False),
             }
             if project
             else {}

--- a/exporters/common.py
+++ b/exporters/common.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -25,4 +25,25 @@ class ExportChunk:
         return self.metadata.get("step_id")
 
 
-__all__ = ["ExportChunk"]
+@dataclass
+class SplitSpec:
+    """Specification for applying train/val/test splits to exports.
+
+    Attributes:
+        strategy: Currently only ``"stratified"`` is supported.
+        by: List of metadata fields to stratify on.
+        fractions: Mapping of split name to desired fraction.
+        seed: Optional random seed to ensure determinism.
+        tolerance: Allowed deviation in fraction per split.
+    """
+
+    strategy: str = "stratified"
+    by: List[str] = field(default_factory=list)
+    fractions: Dict[str, float] = field(
+        default_factory=lambda: {"train": 0.8, "test": 0.2}
+    )
+    seed: Optional[int] = None
+    tolerance: float = 0.03
+
+
+__all__ = ["ExportChunk", "SplitSpec"]

--- a/exporters/splitter.py
+++ b/exporters/splitter.py
@@ -1,22 +1,35 @@
 import random
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
+
+from .common import SplitSpec
 
 
-def apply_split(chunks: List[dict], spec: Dict) -> Tuple[List[dict], Dict[str, int]]:
-    strategy = spec.get("strategy")
-    if strategy != "stratified":
+def _get_field(ch: dict, field: str):
+    """Fetch a field from chunk root, metadata, or source."""
+
+    if field in ch:
+        return ch[field]
+    meta = ch.get("metadata", {})
+    if field in meta:
+        return meta[field]
+    src = ch.get("source", {})
+    return src.get(field)
+
+
+def apply_split(
+    chunks: List[dict], spec: Union[Dict, SplitSpec]
+) -> Tuple[List[dict], Dict[str, int]]:
+    if isinstance(spec, dict):
+        spec = SplitSpec(**spec)
+    if spec.strategy != "stratified":
         raise ValueError("unsupported split strategy")
-    by = spec.get("by") or []
-    seed = spec.get("seed")
-    fractions = spec.get("fractions", {"train": 0.8, "test": 0.2})
-    rnd = random.Random(seed)
+    rnd = random.Random(spec.seed)
     docs: Dict[str, List[dict]] = defaultdict(list)
     meta_vals: Dict[str, Tuple] = {}
     for ch in chunks:
         docs[ch["doc_id"]].append(ch)
-        meta = ch.get("metadata", {})
-        key = tuple(meta.get(f) for f in by)
+        key = tuple(_get_field(ch, f) for f in spec.by)
         meta_vals[ch["doc_id"]] = key
     groups: Dict[Tuple, List[str]] = defaultdict(list)
     for doc_id, key in meta_vals.items():
@@ -25,21 +38,28 @@ def apply_split(chunks: List[dict], spec: Dict) -> Tuple[List[dict], Dict[str, i
     for key, doc_ids in groups.items():
         rnd.shuffle(doc_ids)
         n = len(doc_ids)
-        items = list(fractions.items())
+        items = list(spec.fractions.items())
         start = 0
         for i, (name, frac) in enumerate(items):
-            count = int(round(frac * n))
             if i == len(items) - 1:
-                count = n - start
-            for doc_id in doc_ids[start : start + count]:
+                end = n
+            else:
+                end = start + int(round(frac * n))
+            for doc_id in doc_ids[start:end]:
                 doc_split[doc_id] = name
-            start += count
-    counts = {name: 0 for name in fractions.keys()}
-    default_split = next(iter(fractions.keys()))
+            start = end
+    counts = {name: 0 for name in spec.fractions.keys()}
+    default_split = next(iter(spec.fractions.keys()))
     for doc_id, chs in docs.items():
         split_name = doc_split.get(doc_id, default_split)
         for ch in chs:
             meta = ch.setdefault("metadata", {})
             meta["split"] = split_name
             counts[split_name] += 1
+    total = sum(counts.values())
+    if total:
+        for name, frac in spec.fractions.items():
+            actual = counts[name] / total
+            if abs(actual - frac) > spec.tolerance:
+                raise ValueError("split fractions outside tolerance")
     return chunks, counts


### PR DESCRIPTION
## Summary
- add `SplitSpec` dataclass to describe export split parameters
- implement seeded, stratified document-level splitter with tolerance checks
- record split statistics and handle missing `tables_as_text` in manifest generation
- document completion of F40-07 in STATUS

## Testing
- `make lint`
- `pytest tests/test_stratified_split.py -q`
- `make test` *(fails: coverage command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e7cd7bd0832b9535fea4bc148503