### PR TITLE
[F40-10] Math/Code spans detection

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -114,6 +114,7 @@
 | F40-07 | Stratified & balanced splits | codex | ☑ Done | [PR](#) |  |
 | F40-08 | Near-duplicate filtering | codex | ☑ Done | [PR](#) |  |
 | F40-09 | Embeddings + semantic search | codex | ☑ Done | [PR](#) |  |
+| F40-10 | Math/Code spans detection | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/exporters/common.py
+++ b/exporters/common.py
@@ -19,6 +19,7 @@ class ExportChunk:
     source: Dict[str, Any]
     text_hash: str
     metadata: Dict[str, Any] = field(default_factory=dict)
+    spans: List[Dict[str, Any]] = field(default_factory=list)
 
     @property
     def step_id(self) -> Optional[int]:
@@ -54,4 +55,12 @@ class DedupeOptions:
     dupe_threshold: float = 0.85
 
 
-__all__ = ["ExportChunk", "SplitSpec", "DedupeOptions"]
+def sanitize_export_text(text: str) -> str:
+    """Strip text for export but preserve fenced code blocks intact."""
+
+    if text.lstrip().startswith("```") and text.rstrip().endswith("```"):
+        return text
+    return text.strip()
+
+
+__all__ = ["ExportChunk", "SplitSpec", "DedupeOptions", "sanitize_export_text"]

--- a/parsers/spans.py
+++ b/parsers/spans.py
@@ -1,0 +1,64 @@
+import re
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Span:
+    """Represents a detected span within text."""
+
+    type: str
+    start: int
+    end: int
+    text: str
+
+
+_FENCE_RE = re.compile(r"(?P<fence>```|~~~)(.*?)(?P=fence)", re.DOTALL)
+_INLINE_MATH_RE = re.compile(r"(?<!\\)\$(.+?)(?<!\\)\$")
+_DISPLAY_MATH_RE = re.compile(
+    r"\\\[(.+?)\\\]|(?<!\\)\$\$(.+?)(?<!\\)\$\$",
+    re.DOTALL,
+)
+
+
+def _monospace_blocks(text: str) -> List[tuple[int, int]]:
+    """Detect blocks that look like monospace code from PDFs.
+
+    Heuristic: consecutive lines that start with at least four spaces or a tab
+    are treated as a monospace block.
+    """
+
+    lines = text.splitlines(True)
+    spans: List[tuple[int, int]] = []
+    idx = 0
+    block_start: int | None = None
+    for line in lines:
+        if re.match(r"^[ \t]{4,}", line):
+            if block_start is None:
+                block_start = idx
+        else:
+            if block_start is not None:
+                spans.append((block_start, idx))
+                block_start = None
+        idx += len(line)
+    if block_start is not None:
+        spans.append((block_start, idx))
+    return spans
+
+
+def detect_spans(text: str) -> List[Span]:
+    """Detect fenced code blocks, LaTeX math, and monospace spans."""
+
+    spans: List[Span] = []
+    for m in _FENCE_RE.finditer(text):
+        spans.append(Span("code_fence", m.start(), m.end(), text[m.start() : m.end()]))
+    for m in _DISPLAY_MATH_RE.finditer(text):
+        spans.append(Span("math", m.start(), m.end(), text[m.start() : m.end()]))
+    for m in _INLINE_MATH_RE.finditer(text):
+        spans.append(Span("math", m.start(), m.end(), text[m.start() : m.end()]))
+    for start, end in _monospace_blocks(text):
+        spans.append(Span("monospace", start, end, text[start:end]))
+    return sorted(spans, key=lambda s: s.start)
+
+
+__all__ = ["Span", "detect_spans"]

--- a/tests/test_spans_detection.py
+++ b/tests/test_spans_detection.py
@@ -1,0 +1,30 @@
+# span detection tests
+from exporters.common import sanitize_export_text
+from parsers.spans import detect_spans
+
+
+def test_detects_fenced_code() -> None:
+    text = "Here is code:\n```python\nprint('hi')\n```\nEnd"
+    spans = detect_spans(text)
+    codes = [s for s in spans if s.type == "code_fence"]
+    assert codes and codes[0].text.startswith("```python")
+
+
+def test_detects_latex_math() -> None:
+    text = "Inline math $E=mc^2$ and display $$a^2+b^2=c^2$$"
+    spans = detect_spans(text)
+    texts = [s.text for s in spans if s.type == "math"]
+    assert "$E=mc^2$" in texts
+    assert "$$a^2+b^2=c^2$$" in texts
+
+
+def test_detects_monospace_block() -> None:
+    text = "    def add(x, y):\n        return x + y"
+    spans = detect_spans(text)
+    assert any(s.type == "monospace" for s in spans)
+
+
+def test_sanitize_export_preserves_fence() -> None:
+    code = "```\nprint('hi')\n```"
+    assert sanitize_export_text(code) == code
+    assert sanitize_export_text("  text ") == "text"


### PR DESCRIPTION
## Summary
- detect fenced code, LaTeX math, and monospace spans
- preserve fenced blocks when exporting text

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a9f37d2c60832b8547d03b1c088728