### PR TITLE
[F40-13] CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ scorecard: ## Run golden-set scorecard
 	$(PY) scripts/generate_bundles.py
 	$(PY) scripts/scorecard.py --path examples/bundles
 
+cli: ## Run instructify CLI (use ARGS="<cmd> ...")
+	$(PY) scripts/instructify_cli.py $(ARGS)
+
 demo: ## End-to-end: ingest → parse → curate (LS) → export
 	@if [ -x scripts/demo.sh ]; then \
 		bash scripts/demo.sh ; \
@@ -78,4 +81,4 @@ clean: ## Remove build cache & __pycache__
 	find . -type d -name "__pycache__" -exec rm -rf {} + || true
 	rm -rf .pytest_cache .mypy_cache .ruff_cache dist build || true
 
-.PHONY: help setup dev down migrate lint test scorecard demo clean
+.PHONY: help setup dev down migrate lint test scorecard cli demo clean

--- a/STATUS.md
+++ b/STATUS.md
@@ -117,6 +117,7 @@
 | F40-10 | Math/Code spans detection | codex | ☑ Done | [PR](#) |  |
 | F40-11 | Multilingual OCR & language tags | codex | ☑ Done | [PR](#) |  |
 | F40-12 | RAG eval harness | codex | ☑ Done | [PR](#) |  |
+| F40-13 | CLI | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/scripts/instructify_cli.py
+++ b/scripts/instructify_cli.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Unified CLI for common Instructify API workflows.
+
+This Typer-based CLI wraps the public API to provide
+simple commands for automation and CI.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import requests  # type: ignore[import-untyped]
+import typer  # type: ignore[import-not-found]
+
+from scripts import scorecard
+
+API_URL = os.environ.get("API_URL", "http://localhost:8000")
+
+app = typer.Typer(help="Interact with the Instructify API")
+
+
+@app.command()
+def ingest(project_id: str, path: Path) -> None:
+    """Ingest a document for a project via the API."""
+    with path.open("rb") as f:
+        resp = requests.post(
+            f"{API_URL}/ingest", params={"project_id": project_id}, files={"file": f}
+        )
+    typer.echo(resp.json())
+
+
+@app.command()
+def reparse(doc_id: str) -> None:
+    """Trigger re-parsing for an existing document."""
+    resp = requests.post(f"{API_URL}/documents/{doc_id}/reparse")
+    typer.echo(resp.json())
+
+
+@app.command()
+def export(doc_id: str, fmt: str = typer.Argument("jsonl")) -> None:
+    """Export a document in the given format."""
+    resp = requests.post(f"{API_URL}/export/{fmt}", json={"doc_ids": [doc_id]})
+    typer.echo(resp.json())
+
+
+release_app = typer.Typer(help="Manage dataset releases")
+
+
+@release_app.command("create")
+def release_create(project_id: str) -> None:
+    """Create a new dataset release for a project."""
+    resp = requests.post(f"{API_URL}/projects/{project_id}/releases")
+    typer.echo(resp.json())
+
+
+@release_app.command("diff")
+def release_diff(base: str, compare: str) -> None:
+    """Diff two releases and show changes."""
+    resp = requests.get(
+        f"{API_URL}/releases/diff", params={"base": base, "compare": compare}
+    )
+    typer.echo(resp.json())
+
+
+app.add_typer(release_app, name="release")
+
+
+@app.command()
+def scorecard_cli(
+    path: Path = typer.Option(Path("examples/bundles"), "--path")
+) -> None:
+    """Run scorecard checks on example bundles."""
+    ok = scorecard.run(path)
+    raise typer.Exit(code=0 if ok else 1)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from typer.testing import CliRunner  # type: ignore[import-not-found]
+
+from scripts import instructify_cli
+
+
+def test_cli_commands(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    calls = {}
+
+    def fake_post(url, params=None, files=None, json=None):
+        calls["url"] = url
+        calls["params"] = params
+        calls["files"] = files
+        calls["json"] = json
+
+        class Resp:
+            def json(self) -> dict[str, str]:
+                return {"ok": "post"}
+
+        return Resp()
+
+    def fake_get(url, params=None):
+        calls["url"] = url
+        calls["params"] = params
+
+        class Resp:
+            def json(self) -> dict[str, str]:
+                return {"ok": "get"}
+
+        return Resp()
+
+    monkeypatch.setattr(instructify_cli.requests, "post", fake_post)
+    monkeypatch.setattr(instructify_cli.requests, "get", fake_get)
+
+    file = tmp_path / "doc.txt"
+    file.write_text("hello")
+    result = runner.invoke(instructify_cli.app, ["ingest", "proj", str(file)])
+    assert result.exit_code == 0
+    assert calls["url"].endswith("/ingest")
+
+    result = runner.invoke(instructify_cli.app, ["reparse", "doc1"])
+    assert result.exit_code == 0
+    assert calls["url"].endswith("/documents/doc1/reparse")
+
+    result = runner.invoke(instructify_cli.app, ["export", "doc1", "csv"])
+    assert result.exit_code == 0
+    assert calls["url"].endswith("/export/csv")
+
+    result = runner.invoke(instructify_cli.app, ["release", "create", "proj"])
+    assert result.exit_code == 0
+    assert calls["url"].endswith("/projects/proj/releases")
+
+    result = runner.invoke(instructify_cli.app, ["release", "diff", "r1", "r2"])
+    assert result.exit_code == 0
+    assert calls["url"].endswith("/releases/diff")
+    assert calls["params"] == {"base": "r1", "compare": "r2"}
+
+    def fake_run(path: Path) -> bool:
+        calls["path"] = path
+        return True
+
+    monkeypatch.setattr(instructify_cli.scorecard, "run", fake_run)
+    result = runner.invoke(instructify_cli.app, ["scorecard", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert calls["path"] == tmp_path


### PR DESCRIPTION
## Summary
- add Typer-based CLI for ingest, reparse, export, release, and scorecard
- expose CLI via `make cli`
- cover CLI with smoke test and update status

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a9fc2de5f0832b819162b00b669f28