### PR TITLE
[F40-15] Guideline assistant

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -119,6 +119,7 @@
 | F40-12 | RAG eval harness | codex | ☑ Done | [PR](#) |  |
 | F40-13 | CLI | codex | ☑ Done | [PR](#) |  |
 | F40-14 | Notifications | codex | ☑ Done | [PR](#) |  |
+| F40-15 | Guideline assistant | codex | ☐ In Progress | [PR](#) |  |
 
 ---
 

--- a/core/guidelines.py
+++ b/core/guidelines.py
@@ -1,0 +1,23 @@
+import logging
+from dataclasses import dataclass
+
+
+@dataclass
+class GuidelineUsage:
+    """Record a guideline assistant usage event."""
+
+    user: str
+    action: str
+    field: str | None = None
+
+
+def log_guideline_usage(event: GuidelineUsage) -> None:
+    """Log a guideline assistant usage event.
+
+    The log is structured so that analytics systems can parse it later.
+    """
+    logger = logging.getLogger("guidelines")
+    logger.info(
+        "guideline_usage",
+        extra={"user": event.user, "action": event.action, "field": event.field},
+    )

--- a/tests/test_guideline_assistant_stub.py
+++ b/tests/test_guideline_assistant_stub.py
@@ -1,0 +1,11 @@
+from core.guidelines import GuidelineUsage, log_guideline_usage
+
+
+def test_log_guideline_usage(caplog):
+    event = GuidelineUsage(user="tester", action="view", field="severity")
+    with caplog.at_level("INFO"):
+        log_guideline_usage(event)
+    record = caplog.records[0]
+    assert record.user == "tester"
+    assert record.action == "view"
+    assert record.field == "severity"

--- a/ui/curation-lite/components/ChunkEditor.tsx
+++ b/ui/curation-lite/components/ChunkEditor.tsx
@@ -29,15 +29,21 @@ export function ChunkEditor({ chunk, onChange }: Props) {
           </div>
         ))}
       {Object.entries(suggestions).map(([field, s]: any) => (
-        <button
-          key={field}
-          onClick={() => {
-            handleChange(field, s.value);
-            acceptSuggestion(chunk.id, field, 'dev');
-          }}
-        >
-          Accept {field}: {String(s.value)}
-        </button>
+        <div key={field} style={{ marginTop: '0.5rem' }}>
+          <button
+            onClick={() => {
+              handleChange(field, s.value);
+              acceptSuggestion(chunk.id, field, 'dev');
+            }}
+          >
+            Accept {field}: {String(s.value)}
+          </button>
+          {s.rationale && (
+            <div style={{ fontSize: '0.8em', color: '#555' }}>
+              Why: {s.rationale}
+            </div>
+          )}
+        </div>
       ))}
     </div>
   );

--- a/ui/curation-lite/components/GuidelineSidebar.tsx
+++ b/ui/curation-lite/components/GuidelineSidebar.tsx
@@ -1,0 +1,38 @@
+interface GuidelineField {
+  field: string;
+  helptext?: string;
+  examples?: string[];
+}
+
+interface Props {
+  guidelines: GuidelineField[];
+}
+
+export function GuidelineSidebar({ guidelines }: Props) {
+  return (
+    <aside
+      style={{
+        width: '25%',
+        padding: '1rem',
+        borderLeft: '1px solid #ccc',
+        overflowY: 'auto',
+        height: '100vh',
+      }}
+    >
+      <h2>Guidelines</h2>
+      {guidelines.map(g => (
+        <div key={g.field} style={{ marginBottom: '1rem' }}>
+          <strong>{g.field}</strong>
+          {g.helptext && <p>{g.helptext}</p>}
+          {g.examples && g.examples.length > 0 && (
+            <ul>
+              {g.examples.map((ex, i) => (
+                <li key={i}>{ex}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/ui/curation-lite/lib/api.ts
+++ b/ui/curation-lite/lib/api.ts
@@ -28,3 +28,15 @@ export function acceptSuggestion(chunkId: string, field: string, user: string) {
     body: JSON.stringify({ user }),
   });
 }
+
+export function fetchGuidelines(projectId: string) {
+  return apiFetch(`/projects/${projectId}/taxonomy/guidelines`);
+}
+
+export function logGuidelineUsage(event: { action: string; field?: string }) {
+  return apiFetch('/guidelines/usage', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(event),
+  }).catch(() => undefined);
+}

--- a/ui/curation-lite/pages/index.tsx
+++ b/ui/curation-lite/pages/index.tsx
@@ -1,16 +1,21 @@
 import { useEffect, useState } from 'react';
 import { ChunkList, Chunk } from '../components/ChunkList';
+import { GuidelineSidebar } from '../components/GuidelineSidebar';
 import { useHotkeys } from '../hooks/useHotkeys';
 import { useUndo } from '../hooks/useUndo';
-import { apiFetch } from '../lib/api';
+import { apiFetch, fetchGuidelines, logGuidelineUsage } from '../lib/api';
 
 export default function Home() {
   const [chunks, setChunks] = useState<Chunk[]>([]);
   const [filter, setFilter] = useState('');
+  const [guidelines, setGuidelines] = useState<any[]>([]);
   const history = useUndo<Chunk[]>([]);
 
   const docId = typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search).get('doc') || ''
+    : '';
+  const projectId = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('project') || ''
     : '';
 
   useEffect(() => {
@@ -20,6 +25,16 @@ export default function Home() {
       history.setState(data.chunks);
     });
   }, [docId]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    fetchGuidelines(projectId)
+      .then((g: any[]) => {
+        setGuidelines(g);
+        logGuidelineUsage({ action: 'view' });
+      })
+      .catch(() => undefined);
+  }, [projectId]);
 
   useHotkeys({
     'ctrl+z': history.undo,
@@ -33,14 +48,17 @@ export default function Home() {
   );
 
   return (
-    <div>
-      <h1>Curation Lite</h1>
-      <input
-        placeholder="filter"
-        value={filter}
-        onChange={e => setFilter(e.target.value)}
-      />
-      <ChunkList chunks={filtered} onChange={setChunks} selection={history} />
+    <div style={{ display: 'flex' }}>
+      <div style={{ flex: 1 }}>
+        <h1>Curation Lite</h1>
+        <input
+          placeholder="filter"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+        />
+        <ChunkList chunks={filtered} onChange={setChunks} selection={history} />
+      </div>
+      <GuidelineSidebar guidelines={guidelines} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add usage logging helper for guideline assistant
- display rationale and field help in Curation Lite side panel
- cover guideline usage logging with a stub test

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aa00e28bf8832bba5a546d51c65d49