### PR TITLE
Add project parsing field defaults and migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ setup: ## Create venv and install deps (uv/poetry/pip fallback)
 
 dev: ## Run api + worker + deps via docker-compose
 	$(COMPOSE) up -d
+	$(MAKE) dev-migrate
 	$(COMPOSE) ps
 	@echo "▶ tailing logs (Ctrl+C to detach)"
 	$(COMPOSE) logs -f api worker
@@ -43,6 +44,9 @@ down: ## Stop and remove containers
 	$(COMPOSE) down -v
 
 migrate: ## Run Alembic migrations
+	$(ALEMBIC) upgrade head
+
+dev-migrate: ## Run Alembic migrations on dev startup
 	$(ALEMBIC) upgrade head
 
 lint: ## Run black, isort, mypy
@@ -81,4 +85,4 @@ clean: ## Remove build cache & __pycache__
 	find . -type d -name "__pycache__" -exec rm -rf {} + || true
 	rm -rf .pytest_cache .mypy_cache .ruff_cache dist build || true
 
-.PHONY: help setup dev down migrate lint test scorecard cli demo clean
+.PHONY: help setup dev down migrate dev-migrate lint test scorecard cli demo clean

--- a/STATUS.md
+++ b/STATUS.md
@@ -78,6 +78,7 @@
 | F1-01 | CI pipeline | codex | ☑ Done | [PR](#) |  |
 | F2-01 | Postman pack + README | codex | ☑ Done | [PR](#) |  |
 | E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
+| C10-11 | Project parsing fields migration | codex | ☑ Done | PR TBD |  |
 | S2-01 | GET /projects list endpoint | codex | ☑ Done | PR TBD |  |
 | C10-01 | Celery Canvas orchestrator | codex | ☑ Done | PR TBD |  |
 | C10-02 | Preflight & normalization | codex | ☑ Done | PR TBD |  |

--- a/alembic/versions/0010_project_parsing_defaults.py
+++ b/alembic/versions/0010_project_parsing_defaults.py
@@ -1,0 +1,45 @@
+"""add project parsing fields with defaults"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0010"
+down_revision = "add_project_parsing_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE projects
+        ADD COLUMN IF NOT EXISTS block_pii BOOLEAN NOT NULL DEFAULT false
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE projects
+        ADD COLUMN IF NOT EXISTS ocr_langs JSONB NOT NULL DEFAULT '["eng"]'::jsonb
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE projects
+        ADD COLUMN IF NOT EXISTS min_text_len_for_ocr INTEGER NOT NULL DEFAULT 50
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE projects
+        ADD COLUMN IF NOT EXISTS html_crawl_limits JSONB NOT NULL DEFAULT '{"max_depth":2,"max_pages":50}'::jsonb
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE projects DROP COLUMN IF EXISTS html_crawl_limits")
+    op.execute("ALTER TABLE projects DROP COLUMN IF EXISTS min_text_len_for_ocr")
+    op.execute("ALTER TABLE projects DROP COLUMN IF EXISTS ocr_langs")
+    op.execute("ALTER TABLE projects DROP COLUMN IF EXISTS block_pii")

--- a/models/project.py
+++ b/models/project.py
@@ -1,11 +1,13 @@
 import uuid
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 from .base import Base
+
+json_type = sa.JSON().with_variant(JSONB, "postgresql")
 
 
 class Project(Base):
@@ -34,12 +36,23 @@ class Project(Base):
     block_pii: Mapped[bool] = mapped_column(
         sa.Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
-    ocr_langs: Mapped[list[str]] = mapped_column(sa.JSON, nullable=False, default=list)
+    ocr_langs: Mapped[list[str]] = mapped_column(
+        json_type,
+        nullable=False,
+        default=lambda: ["eng"],
+        server_default=sa.text("'[\"eng\"]'::jsonb"),
+    )
     min_text_len_for_ocr: Mapped[int] = mapped_column(
-        sa.Integer, nullable=False, default=0
+        sa.Integer,
+        nullable=False,
+        default=50,
+        server_default=sa.text("50"),
     )
     html_crawl_limits: Mapped[dict[str, int]] = mapped_column(
-        sa.JSON, nullable=False, default=dict
+        json_type,
+        nullable=False,
+        default=lambda: {"max_depth": 2, "max_pages": 50},
+        server_default=sa.text('\'{"max_depth":2,"max_pages":50}\'::jsonb'),
     )
     created_at: Mapped[sa.types.DateTime] = mapped_column(
         sa.DateTime(timezone=True), server_default=func.now(), nullable=False


### PR DESCRIPTION
## Summary
- add migration with parsing fields defaults
- set Project ORM to use JSONB types and Python defaults
- run migrations automatically when starting dev

## Testing
- `make lint` *(fails: Interrupted)*
- `make test`
- `make migrate` *(fails: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68aabb2a1c9c832ba762d76b72c6c4cf