### PR TITLE
feature/jsonb-native-types

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -122,6 +122,7 @@
 | F40-13 | CLI | codex | ☑ Done | [PR](#) |  |
 | F40-14 | Notifications | codex | ☑ Done | [PR](#) |  |
 | F40-15 | Guideline assistant | codex | ☐ In Progress | [PR](#) |  |
+| N/A | JSONB native types | codex | ☑ Done | PR TBD |  |
 
 ---
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -82,9 +82,11 @@ class ProjectCreate(BaseModel):
     max_suggestions_per_doc: int = 200
     suggestion_timeout_ms: int = 500
     block_pii: bool = False
-    ocr_langs: List[str] = []
+    ocr_langs: List[str] = Field(default_factory=lambda: ["eng"])
     min_text_len_for_ocr: int = 0
-    html_crawl_limits: Dict[str, int] = {}
+    html_crawl_limits: Dict[str, int] = Field(
+        default_factory=lambda: {"max_depth": 2, "max_pages": 50}
+    )
 
 
 class ProjectResponse(BaseModel):

--- a/models/chunk.py
+++ b/models/chunk.py
@@ -2,12 +2,13 @@ import uuid
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
 from .base import Base
 
-json_type = sa.JSON().with_variant(JSONB, "postgresql")
+json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
 
 
 class Chunk(Base):
@@ -21,10 +22,10 @@ class Chunk(Base):
     )
     version: Mapped[int] = mapped_column(sa.Integer, nullable=False)
     order: Mapped[int] = mapped_column(sa.Integer, nullable=False)
-    content: Mapped[dict] = mapped_column("content", json_type, nullable=False)
+    content: Mapped[dict] = mapped_column("content", json_dict, nullable=False)
     text_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     meta: Mapped[dict] = mapped_column(
-        "metadata", json_type, default=dict, nullable=False
+        "metadata", json_dict, default=dict, nullable=False
     )
     rev: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=1)
     created_at: Mapped[sa.types.DateTime] = mapped_column(

--- a/models/document.py
+++ b/models/document.py
@@ -3,6 +3,7 @@ import uuid
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -16,7 +17,7 @@ class DocumentStatus(str, enum.Enum):
     FAILED = "failed"
 
 
-json_type = sa.JSON().with_variant(JSONB, "postgresql")
+json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
 
 
 class Document(Base):
@@ -65,7 +66,7 @@ class DocumentVersion(Base):
     size: Mapped[int] = mapped_column(sa.Integer, nullable=False)
     status: Mapped[str] = mapped_column(sa.String, nullable=False)
     meta: Mapped[dict] = mapped_column(
-        "metadata", json_type, default=dict, nullable=False
+        "metadata", json_dict, default=dict, nullable=False
     )
     created_at: Mapped[sa.types.DateTime] = mapped_column(
         sa.DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/models/project.py
+++ b/models/project.py
@@ -2,12 +2,14 @@ import uuid
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict, MutableList
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 from .base import Base
 
-json_type = sa.JSON().with_variant(JSONB, "postgresql")
+json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
+json_list = MutableList.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
 
 
 class Project(Base):
@@ -37,10 +39,10 @@ class Project(Base):
         sa.Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
     ocr_langs: Mapped[list[str]] = mapped_column(
-        json_type,
+        json_list,
         nullable=False,
         default=lambda: ["eng"],
-        server_default=sa.text("'[\"eng\"]'::jsonb"),
+        server_default=sa.text("'[\"eng\"]'"),
     )
     min_text_len_for_ocr: Mapped[int] = mapped_column(
         sa.Integer,
@@ -49,10 +51,10 @@ class Project(Base):
         server_default=sa.text("50"),
     )
     html_crawl_limits: Mapped[dict[str, int]] = mapped_column(
-        json_type,
+        json_dict,
         nullable=False,
         default=lambda: {"max_depth": 2, "max_pages": 50},
-        server_default=sa.text('\'{"max_depth":2,"max_pages":50}\'::jsonb'),
+        server_default=sa.text('\'{"max_depth":2,"max_pages":50}\''),
     )
     created_at: Mapped[sa.types.DateTime] = mapped_column(
         sa.DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/tests/test_jsonb_native_types.py
+++ b/tests/test_jsonb_native_types.py
@@ -1,0 +1,80 @@
+from models import (
+    Chunk,
+    Document,
+    DocumentStatus,
+    DocumentVersion,
+    Project,
+)
+from tests.conftest import PROJECT_ID_1
+
+
+def test_jsonb_native_types_round_trip(test_app) -> None:
+    _, _, _, SessionLocal = test_app
+
+    # project list/dict defaults and updates
+    with SessionLocal() as session:
+        project = session.get(Project, PROJECT_ID_1)
+        project.ocr_langs.append("fra")
+        project.html_crawl_limits["max_pages"] = 10
+        session.commit()
+
+    with SessionLocal() as session:
+        project = session.get(Project, PROJECT_ID_1)
+        assert isinstance(project.ocr_langs, list)
+        assert isinstance(project.html_crawl_limits, dict)
+        assert project.ocr_langs[-1] == "fra"
+        assert project.html_crawl_limits["max_pages"] == 10
+
+        doc = Document(project_id=project.id, source_type="pdf")
+        session.add(doc)
+        session.flush()
+        doc_id = doc.id
+
+        version = DocumentVersion(
+            document_id=doc_id,
+            project_id=project.id,
+            version=1,
+            doc_hash="hash",
+            mime="application/pdf",
+            size=1,
+            status=DocumentStatus.INGESTED.value,
+            meta={"foo": "bar"},
+        )
+        session.add(version)
+        session.flush()
+        version_id = version.id
+
+        chunk = Chunk(
+            document_id=doc_id,
+            version=1,
+            order=1,
+            content={"text": "hello"},
+            text_hash="hash1",
+            meta={"tags": ["a"]},
+        )
+        session.add(chunk)
+        session.flush()
+        chunk_id = chunk.id
+        session.commit()
+
+    with SessionLocal() as session:
+        version = session.get(DocumentVersion, version_id)
+        assert isinstance(version.meta, dict)
+        assert version.meta["foo"] == "bar"
+        version.meta["bar"] = "baz"
+        session.commit()
+
+    with SessionLocal() as session:
+        version = session.get(DocumentVersion, version_id)
+        assert version.meta["bar"] == "baz"
+
+    with SessionLocal() as session:
+        chunk = session.get(Chunk, chunk_id)
+        assert isinstance(chunk.meta, dict)
+        assert chunk.meta == {"tags": ["a"]}
+        chunk.meta["tags"] = chunk.meta["tags"] + ["b"]
+        session.commit()
+
+    with SessionLocal() as session:
+        chunk = session.get(Chunk, chunk_id)
+        assert chunk.meta["tags"] == ["a", "b"]


### PR DESCRIPTION
## Summary
- ensure JSONB columns use SQLAlchemy MutableDict/MutableList with native defaults
- fix ProjectCreate schema to return dict/list types
- test round-trip of dict/list through JSONB fields

## Testing
- `make lint`
- `make test`
- `pytest tests/test_jsonb_native_types.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aabeb7ee68832b9ed1ee23a659fb73