### PR TITLE
fix: robust worker transactions and JSONB

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -77,7 +77,7 @@
 | E9-04 | Project onboarding API | codex | ☑ Done | PR TBD |  |
 | F1-01 | CI pipeline | codex | ☑ Done | [PR](#) |  |
 | F2-01 | Postman pack + README | codex | ☑ Done | [PR](#) |  |
-| E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | PR TBD |  |
+| E3-06 | Worker parse pipeline & error handling | codex | ☑ Done | [PR](#) |  |
 | C10-11 | Project parsing fields migration | codex | ☑ Done | PR TBD |  |
 | S2-01 | GET /projects list endpoint | codex | ☑ Done | PR TBD |  |
 | C10-01 | Celery Canvas orchestrator | codex | ☑ Done | PR TBD |  |
@@ -122,7 +122,7 @@
 | F40-13 | CLI | codex | ☑ Done | [PR](#) |  |
 | F40-14 | Notifications | codex | ☑ Done | [PR](#) |  |
 | F40-15 | Guideline assistant | codex | ☐ In Progress | [PR](#) |  |
-| N/A | JSONB native types | codex | ☑ Done | PR TBD |  |
+| N/A | JSONB native types | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/models/chunk.py
+++ b/models/chunk.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql import func
 
 from .base import Base
 
-json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
+json_dict = MutableDict.as_mutable(JSONB)
 
 
 class Chunk(Base):

--- a/models/document.py
+++ b/models/document.py
@@ -12,12 +12,13 @@ from .base import Base
 
 class DocumentStatus(str, enum.Enum):
     INGESTED = "ingested"
+    PARSING = "parsing"
     PARSED = "parsed"
     NEEDS_REVIEW = "needs_review"
     FAILED = "failed"
 
 
-json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
+json_dict = MutableDict.as_mutable(JSONB)
 
 
 class Document(Base):

--- a/models/project.py
+++ b/models/project.py
@@ -8,8 +8,8 @@ from sqlalchemy.sql import func
 
 from .base import Base
 
-json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
-json_list = MutableList.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
+json_dict = MutableDict.as_mutable(JSONB)
+json_list = MutableList.as_mutable(JSONB)
 
 
 class Project(Base):

--- a/tests/test_worker_error_rollback.py
+++ b/tests/test_worker_error_rollback.py
@@ -1,0 +1,42 @@
+import pytest
+import sqlalchemy as sa
+
+from models import DocumentStatus, DocumentVersion
+from tests.conftest import PROJECT_ID_1
+from worker import main as worker_main
+
+
+def _setup_worker(store, SessionLocal):
+    worker_main.create_client = lambda **kwargs: store.client
+    worker_main.settings.s3_bucket = store.bucket
+    worker_main.SessionLocal = SessionLocal
+
+
+def test_parse_error_rolls_back(test_app, monkeypatch):
+    client, store, _, SessionLocal = test_app
+    _setup_worker(store, SessionLocal)
+
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("a.txt", b"data", "text/plain")},
+    )
+    doc_id = resp.json()["doc_id"]
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(worker_main, "_run_parse", boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker_main.parse_document(doc_id)
+    assert "InFailedSqlTransaction" not in str(excinfo.value)
+
+    with SessionLocal() as db:
+        dv = db.scalar(
+            sa.select(DocumentVersion).where(DocumentVersion.document_id == doc_id)
+        )
+        assert dv is not None
+        assert dv.status == DocumentStatus.FAILED.value
+        assert "error" in dv.meta
+        assert dv.meta.get("error_artifact", "").startswith("http")

--- a/worker/main.py
+++ b/worker/main.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+import traceback
+from datetime import datetime
 from typing import Any, cast
 from urllib.parse import urljoin, urlparse
 
 import httpx
 import sqlalchemy as sa
 from bs4 import BeautifulSoup, Tag
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 from chunking.chunker import chunk_blocks
 from core.correlation import get_request_id, set_request_id
@@ -17,10 +19,16 @@ from core.logging import configure_logging
 from core.metrics import compute_parse_metrics, enforce_quality_gates
 from core.pii import detect_pii
 from core.settings import get_settings
-from models import Document, DocumentStatus
+from models import Document, DocumentStatus, DocumentVersion
 from parser_pipeline.metrics import char_coverage
 from parsers import registry
-from storage.object_store import ObjectStore, create_client, raw_key
+from storage.object_store import (
+    ObjectStore,
+    create_client,
+    derived_key,
+    raw_key,
+    signed_url,
+)
 from worker.celery_app import app
 from worker.derived_writer import upsert_chunks, write_redactions
 from worker.pipeline import get_parser_settings
@@ -50,6 +58,121 @@ def _get_store() -> ObjectStore:
         secure=settings.minio_secure,
     )
     return ObjectStore(client=client, bucket=settings.s3_bucket)
+
+
+def _update_version(
+    db: Session,
+    version_id: str,
+    *,
+    status: str | None = None,
+    meta_patch: dict | None = None,
+) -> None:
+    dv = db.get(DocumentVersion, version_id)
+    if not dv:
+        return
+    if status is not None:
+        dv.status = status
+    if meta_patch:
+        base = dict(dv.meta or {})
+        for k, v in meta_patch.items():
+            if k == "parse" and isinstance(v, dict):
+                existing = dict(base.get("parse") or {})
+                existing.update(v)
+                base["parse"] = existing
+            else:
+                base[k] = v
+        dv.meta = base
+    db.commit()
+
+
+def _run_parse(
+    db: Session, store: ObjectStore, doc: Document, dv: DocumentVersion
+) -> tuple[list[dict], dict, dict, dict[str, list[dict[str, str]]]]:
+    filename = dv.meta.get("filename")
+    if not isinstance(filename, str):
+        raise RuntimeError("filename missing")
+    data = store.get_bytes(raw_key(doc.id, filename))
+    parser_cls = registry.get(dv.mime)
+    logger.info("Picked parser: %s for %s", parser_cls.__name__, dv.mime)
+    try:
+        blocks = list(parser_cls.parse(data, store=store, doc_id=doc.id))  # type: ignore[call-arg]
+    except TypeError:
+        blocks = list(parser_cls.parse(data))
+    chunks = chunk_blocks(blocks)
+    extracted_text = "".join(b.text for b in blocks if getattr(b, "text", ""))
+    coverage = char_coverage(extracted_text)
+    metrics = compute_parse_metrics(chunks, mime=dv.mime)
+    metrics["text_coverage"] = coverage["ascii_ratio"] + coverage["latin1_ratio"]
+    metrics["utf_other_ratio"] = coverage["other_ratio"]
+
+    project = doc.project
+    parser_settings = get_parser_settings(project)
+    parse_meta: dict = {"char_coverage_extracted": coverage}
+    meta_patch = {
+        "metrics": metrics,
+        "parser_settings": parser_settings,
+        "parse": parse_meta,
+    }
+
+    if project.use_rules_suggestor or project.use_mini_llm:
+        total = 0
+        for ch in chunks:
+            if ch.content.type != "text":
+                continue
+            remaining = (
+                project.max_suggestions_per_doc or settings.max_suggestions_per_doc
+            ) - total
+            if remaining <= 0:
+                break
+            sugg = suggest(
+                ch.content.text or "",
+                use_rules_suggestor=project.use_rules_suggestor,
+                use_mini_llm=project.use_mini_llm,
+                max_suggestions=remaining,
+                suggestion_timeout_ms=(
+                    project.suggestion_timeout_ms or settings.suggestion_timeout_ms
+                ),
+            )
+            if sugg:
+                ch.metadata.setdefault("suggestions", {})
+                for key, val in sugg.items():
+                    ch.metadata["suggestions"][key] = val
+                total += len(sugg)
+
+    redactions: dict[str, list[dict[str, str]]] = {}
+    total_pii = 0
+    for ch in chunks:
+        if ch.content.type != "text":
+            continue
+        matches = detect_pii(ch.content.text or "")
+        if matches:
+            ch.metadata.setdefault("suggestions", {})
+            ch.metadata["suggestions"]["redactions"] = [
+                {"type": m.type, "text": m.text} for m in matches
+            ]
+            redactions[str(ch.id)] = [{"type": m.type, "text": m.text} for m in matches]
+            total_pii += len(matches)
+    metrics["pii_count"] = total_pii
+
+    rows = [
+        {
+            "id": str(ch.id),
+            "document_id": doc.id,
+            "version": dv.version,
+            "order": ch.order,
+            "text": ch.content.text,
+            "text_hash": ch.text_hash,
+            "meta": {
+                **ch.metadata,
+                "content_type": ch.content.type,
+                "page": ch.source.page,
+                "section_path": ch.source.section_path,
+            },
+        }
+        for ch in chunks
+    ]
+    parse_meta["counts"] = {"chunks": len(rows)}
+    return rows, metrics, meta_patch, redactions
 
 
 @app.task
@@ -120,119 +243,81 @@ def crawl_document(
 def parse_document(doc_id: str, request_id: str | None = None) -> None:
     set_request_id(request_id)
     store = _get_store()
-    with SessionLocal() as db:
+    db: Session = SessionLocal()
+    rid = request_id or get_request_id() or "no-rid"
+    try:
         doc = db.get(Document, doc_id)
-        if doc is None or doc.latest_version is None:
-            return
-        ver = doc.latest_version
-        filename = ver.meta.get("filename")
+        if not doc or not doc.latest_version_id:
+            raise RuntimeError(f"document or latest version missing: {doc_id=}")
+        dv = db.get(DocumentVersion, doc.latest_version_id)
+        if not dv:
+            raise RuntimeError(f"document version not found: {doc.latest_version_id}")
+
+        _update_version(
+            db,
+            dv.id,
+            status=DocumentStatus.PARSING.value,
+            meta_patch={"request_id": rid},
+        )
+
+        rows, metrics, meta_patch, redactions = _run_parse(db, store, doc, dv)
+
+        chunks_url, manifest_url, deltas = upsert_chunks(
+            db,
+            store,
+            doc_id=doc.id,
+            version=dv.version,
+            rows=rows,
+            metrics=metrics,
+        )
+
+        write_redactions(store, doc.id, redactions)
+        enforce_quality_gates(doc.id, doc.project_id, dv.version, db)
+
+        meta_patch["parse"]["deltas"] = deltas
+        parse_summary = {
+            **meta_patch["parse"],
+            "chunks_url": chunks_url,
+            "manifest_url": manifest_url,
+            "deltas": deltas,
+            "metrics": metrics or {},
+        }
+        meta_patch["parse"] = parse_summary
+
+        _update_version(
+            db,
+            dv.id,
+            status=DocumentStatus.PARSED.value,
+            meta_patch=meta_patch,
+        )
+
+    except Exception as e:
+        db.rollback()
+        tb = traceback.format_exc()
+        err_key = derived_key(
+            doc_id, f"errors/{datetime.utcnow().isoformat()}_{rid}.log"
+        )
+        store.put_bytes(err_key, tb.encode("utf-8"))
+        err_url = signed_url(store, err_key)
         try:
-            data = store.get_bytes(raw_key(doc_id, filename))
-            parser_cls = registry.get(ver.mime)
-            logger.info("Picked parser: %s for %s", parser_cls.__name__, ver.mime)
-            try:
-                blocks = list(parser_cls.parse(data, store=store, doc_id=doc_id))  # type: ignore[call-arg]
-            except TypeError:
-                blocks = list(parser_cls.parse(data))
-            chunks = chunk_blocks(blocks)
-            extracted_text = "".join(b.text for b in blocks if getattr(b, "text", ""))
-            coverage = char_coverage(extracted_text)
-            metrics = compute_parse_metrics(chunks, mime=ver.mime)
-            metrics["text_coverage"] = (
-                coverage["ascii_ratio"] + coverage["latin1_ratio"]
-            )
-            metrics["utf_other_ratio"] = coverage["other_ratio"]
-            meta = dict(ver.meta)
-            project = doc.project
-            parser_settings = get_parser_settings(project)
-            parse_meta = dict(meta.get("parse", {}))
-            parse_meta["char_coverage_extracted"] = coverage
-            meta["metrics"] = metrics
-            meta["parser_settings"] = parser_settings
-            ver.meta = meta
-            if project.use_rules_suggestor or project.use_mini_llm:
-                total = 0
-                for ch in chunks:
-                    if ch.content.type != "text":
-                        continue
-                    remaining = (
-                        project.max_suggestions_per_doc
-                        or settings.max_suggestions_per_doc
-                    ) - total
-                    if remaining <= 0:
-                        break
-                    sugg = suggest(
-                        ch.content.text or "",
-                        use_rules_suggestor=project.use_rules_suggestor,
-                        use_mini_llm=project.use_mini_llm,
-                        max_suggestions=remaining,
-                        suggestion_timeout_ms=(
-                            project.suggestion_timeout_ms
-                            or settings.suggestion_timeout_ms
-                        ),
-                    )
-                    if sugg:
-                        ch.metadata.setdefault("suggestions", {})
-                        for key, val in sugg.items():
-                            ch.metadata["suggestions"][key] = val
-                        total += len(sugg)
-            redactions: dict[str, list[dict[str, str]]] = {}
-            total_pii = 0
-            for ch in chunks:
-                if ch.content.type != "text":
-                    continue
-                matches = detect_pii(ch.content.text or "")
-                if matches:
-                    ch.metadata.setdefault("suggestions", {})
-                    ch.metadata["suggestions"]["redactions"] = [
-                        {"type": m.type, "text": m.text} for m in matches
-                    ]
-                    redactions[str(ch.id)] = [
-                        {"type": m.type, "text": m.text} for m in matches
-                    ]
-                    total_pii += len(matches)
-            metrics["pii_count"] = total_pii
-            rows = [
-                {
-                    "id": str(ch.id),
-                    "document_id": doc_id,
-                    "version": ver.version,
-                    "order": ch.order,
-                    "text": ch.content.text,
-                    "text_hash": ch.text_hash,
-                    "meta": {
-                        **ch.metadata,
-                        "content_type": ch.content.type,
-                        "page": ch.source.page,
-                        "section_path": ch.source.section_path,
+            doc = db.get(Document, doc_id)
+            dv_id = getattr(doc, "latest_version_id", None)
+            if dv_id:
+                _update_version(
+                    db,
+                    dv_id,
+                    status=DocumentStatus.FAILED.value,
+                    meta_patch={
+                        "error": str(e)[:2000],
+                        "error_artifact": err_url,
+                        "request_id": rid,
                     },
-                }
-                for ch in chunks
-            ]
-            ver.status = DocumentStatus.PARSED.value
-            db.add(ver)
-            _, _, deltas = upsert_chunks(
-                db,
-                store,
-                doc_id=doc_id,
-                version=ver.version,
-                rows=rows,
-                metrics=metrics,
-            )
-            parse_meta["counts"] = {"chunks": len(rows)}
-            parse_meta["deltas"] = deltas
-            meta["parse"] = parse_meta
-            ver.meta = meta
-            write_redactions(store, doc_id, redactions)
-            enforce_quality_gates(doc_id, doc.project_id, ver.version, db)
-            db.commit()
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("parse failed: %s", exc)
-            ver.status = DocumentStatus.FAILED.value
-            err_meta: dict[str, Any] = dict(ver.meta or {})
-            err_meta["error"] = str(exc)
-            ver.meta = err_meta
-            db.commit()
+                )
+        except Exception:
+            db.rollback()
+        raise
+    finally:
+        db.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make worker parse_document transactional and store traceback artifacts on failure
- use ORM JSONB fields for document and chunk metadata
- add regression test for worker rollback on parse errors

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aad00bfccc832b878ec2651e2c3feb