### PR TITLE
Fix chunk upsert duplicates and JSONB coercion

### DIFF
--- a/tests/test_jsonb_coercion.py
+++ b/tests/test_jsonb_coercion.py
@@ -1,0 +1,55 @@
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import Base
+from models import Chunk as ChunkModel
+from storage.object_store import ObjectStore
+from tests.conftest import FakeS3Client
+from worker.derived_writer import upsert_chunks
+
+
+@compiles(JSONB, "sqlite")
+def _jsonb_sqlite(type_: JSONB, compiler, **kw):  # pragma: no cover - test helper
+    return "JSON"
+
+
+@pytest.fixture()
+def session_store():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[ChunkModel.__table__])
+    TestingSession = sessionmaker(bind=engine)
+    store = ObjectStore(client=FakeS3Client(), bucket="test")
+    with TestingSession() as session:
+        yield session, store
+
+
+def test_jsonb_coercion(session_store):
+    session, store = session_store
+    cid = uuid.uuid4()
+    rows = [
+        {
+            "id": str(cid),
+            "document_id": "doc",
+            "version": 1,
+            "order": 0,
+            "text": "hello",
+            "text_hash": "h1",
+            "meta": '{"tags": ["a"]}',
+        }
+    ]
+    upsert_chunks(session, store, doc_id="doc", version=1, rows=rows)
+    chunk = session.get(ChunkModel, str(cid))
+    assert isinstance(chunk.meta, dict)
+    assert chunk.meta["tags"] == ["a"]
+    assert isinstance(chunk.content, dict)
+    assert chunk.content["text"] == "hello"

--- a/tests/test_upsert_dedup_in_batch.py
+++ b/tests/test_upsert_dedup_in_batch.py
@@ -1,0 +1,60 @@
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import Base
+from models import Chunk as ChunkModel
+from storage.object_store import ObjectStore
+from tests.conftest import FakeS3Client
+from worker.derived_writer import upsert_chunks
+
+
+@compiles(JSONB, "sqlite")
+def _jsonb_sqlite(type_: JSONB, compiler, **kw):  # pragma: no cover - test helper
+    return "JSON"
+
+
+@pytest.fixture()
+def session_store():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[ChunkModel.__table__])
+    TestingSession = sessionmaker(bind=engine)
+    store = ObjectStore(client=FakeS3Client(), bucket="test")
+    with TestingSession() as session:
+        yield session, store
+
+
+def _make_row(cid: uuid.UUID, order: int, text: str, text_hash: str):
+    return {
+        "id": str(cid),
+        "document_id": "doc",
+        "version": 1,
+        "order": order,
+        "text": text,
+        "text_hash": text_hash,
+        "meta": {},
+    }
+
+
+def test_upsert_dedup_in_batch(session_store):
+    session, store = session_store
+    cid = uuid.uuid4()
+    rows = [
+        _make_row(cid, 0, "a", "h0"),
+        _make_row(cid, 1, "b", "h1"),
+    ]
+    upsert_chunks(session, store, doc_id="doc", version=1, rows=rows)
+    records = session.query(ChunkModel).all()
+    assert len(records) == 1
+    assert records[0].order == 1
+    assert records[0].content.get("text") == "b"
+    assert records[0].text_hash == "h1"


### PR DESCRIPTION
## Summary
- Deduplicate chunk rows by `id` before UPSERT and warn on duplicates
- Coerce metadata/content fields to dicts with `_ensure_dict`
- Handle stringified JSON in rows and write_chunks
- Add tests for dedup logic and JSONB coercion

## Testing
- `make lint`
- `make test`
- `pytest tests/test_upsert_dedup_in_batch.py tests/test_jsonb_coercion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad5a5c370832bb698fc6bbd82c27d