### PR TITLE
feat: add job tracking

### DIFF
--- a/alembic/versions/0010_add_jobs_table.py
+++ b/alembic/versions/0010_add_jobs_table.py
@@ -1,0 +1,79 @@
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0010_add_jobs_table"
+down_revision = "0009_add_project_parsing_fields"
+branch_labels = None
+depends_on = None
+
+job_state = sa.Enum("queued", "running", "succeeded", "failed", name="job_state")
+job_type = sa.Enum(
+    "ingest",
+    "parse",
+    "reparse",
+    "dataset",
+    "export",
+    "qa_generate",
+    name="job_type",
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column("type", job_type, nullable=False),
+        sa.Column(
+            "project_id",
+            sa.Uuid(as_uuid=True),
+            sa.ForeignKey("projects.id"),
+            nullable=False,
+        ),
+        sa.Column("doc_id", sa.Uuid(as_uuid=True), nullable=True),
+        sa.Column("state", job_state, nullable=False),
+        sa.Column(
+            "progress",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("celery_task_id", sa.Text(), nullable=True),
+        sa.Column(
+            "artifacts",
+            sa.JSON().with_variant(postgresql.JSONB, "postgresql"),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "progress >= 0 AND progress <= 100", name="ck_jobs_progress"
+        ),
+    )
+    op.create_index(
+        "ix_jobs_project_state_type",
+        "jobs",
+        ["project_id", "state", "type"],
+    )
+    op.create_index("ix_jobs_doc_id", "jobs", ["doc_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_doc_id", table_name="jobs")
+    op.drop_index("ix_jobs_project_state_type", table_name="jobs")
+    op.drop_table("jobs")
+    job_state.drop(op.get_bind(), checkfirst=False)
+    job_type.drop(op.get_bind(), checkfirst=False)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -195,3 +195,22 @@ class CrawlPayload(BaseModel):
 class ActiveLearningEntry(BaseModel):
     chunk_id: str
     reasons: List[str]
+
+
+class JobResponse(BaseModel):
+    id: UUID
+    type: str
+    project_id: UUID
+    doc_id: UUID | None = None
+    state: str
+    progress: int
+    celery_task_id: str | None = None
+    artifacts: Dict[str, Any]
+    error: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class JobsListResponse(BaseModel):
+    jobs: List[JobResponse]
+    total: int

--- a/docs/postman/InstructifyAI_Labeler_Phase1.postman_collection.json
+++ b/docs/postman/InstructifyAI_Labeler_Phase1.postman_collection.json
@@ -667,6 +667,51 @@
           }
         }
       ]
+    },
+    {
+      "name": "Jobs",
+      "item": [
+        {
+          "name": "Get Job",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/jobs/{{job_id}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "jobs",
+                "{{job_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "List Jobs",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/jobs?project_id={{project_id}}&type={{type}}&state={{state}}&limit={{limit}}&offset={{offset}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "jobs"
+              ],
+              "query": [
+                {"key": "project_id", "value": "{{project_id}}"},
+                {"key": "type", "value": "{{type}}"},
+                {"key": "state", "value": "{{state}}"},
+                {"key": "limit", "value": "{{limit}}"},
+                {"key": "offset", "value": "{{offset}}"}
+              ]
+            }
+          }
+        }
+      ]
     }
   ],
   "variable": [

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,6 +2,7 @@ from .audit import Audit
 from .base import Base
 from .chunk import Chunk
 from .document import Document, DocumentStatus, DocumentVersion
+from .job import Job, JobState, JobType
 from .project import Project
 from .release import Release
 from .taxonomy import Taxonomy
@@ -13,6 +14,9 @@ __all__ = [
     "DocumentVersion",
     "DocumentStatus",
     "Chunk",
+    "Job",
+    "JobType",
+    "JobState",
     "Taxonomy",
     "Audit",
     "Release",

--- a/models/job.py
+++ b/models/job.py
@@ -1,0 +1,72 @@
+import enum
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class JobType(str, enum.Enum):
+    INGEST = "ingest"
+    PARSE = "parse"
+    REPARSE = "reparse"
+    DATASET = "dataset"
+    EXPORT = "export"
+    QA_GENERATE = "qa_generate"
+
+
+class JobState(str, enum.Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+json_dict = MutableDict.as_mutable(JSONB)
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    type: Mapped[JobType] = mapped_column(
+        sa.Enum(JobType, name="job_type"), nullable=False
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), sa.ForeignKey("projects.id"), nullable=False
+    )
+    doc_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    state: Mapped[JobState] = mapped_column(
+        sa.Enum(JobState, name="job_state"),
+        nullable=False,
+        default=JobState.QUEUED,
+    )
+    progress: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.CheckConstraint("progress >= 0 AND progress <= 100"),
+        nullable=False,
+        default=0,
+    )
+    celery_task_id: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    artifacts: Mapped[dict] = mapped_column(json_dict, default=dict, nullable=False)
+    error: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    created_at: Mapped[sa.types.DateTime] = mapped_column(
+        sa.DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[sa.types.DateTime] = mapped_column(
+        sa.DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        sa.Index("ix_jobs_project_state_type", "project_id", "state", "type"),
+        sa.Index("ix_jobs_doc_id", "doc_id"),
+    )

--- a/services/jobs.py
+++ b/services/jobs.py
@@ -1,0 +1,84 @@
+import uuid
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from models import Job, JobState, JobType
+
+
+def create_job(
+    db: Session,
+    job_type: JobType | str,
+    project_id: uuid.UUID,
+    doc_id: uuid.UUID | None = None,
+    celery_task_id: str | None = None,
+) -> Job:
+    job = Job(
+        type=JobType(job_type),
+        project_id=project_id,
+        doc_id=doc_id,
+        celery_task_id=celery_task_id,
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def set_progress(
+    db: Session,
+    job_id: uuid.UUID,
+    progress: int,
+    artifacts: dict[str, Any] | None = None,
+) -> Job | None:
+    job = db.get(Job, job_id)
+    if job is None:
+        return None
+    job.state = JobState.RUNNING
+    job.progress = progress
+    if artifacts:
+        data = dict(job.artifacts or {})
+        data.update(artifacts)
+        job.artifacts = data
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def set_done(
+    db: Session,
+    job_id: uuid.UUID,
+    artifacts: dict[str, Any] | None = None,
+) -> Job | None:
+    job = db.get(Job, job_id)
+    if job is None:
+        return None
+    job.state = JobState.SUCCEEDED
+    job.progress = 100
+    if artifacts:
+        data = dict(job.artifacts or {})
+        data.update(artifacts)
+        job.artifacts = data
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def set_failed(
+    db: Session,
+    job_id: uuid.UUID,
+    error: str,
+    artifacts: dict[str, Any] | None = None,
+) -> Job | None:
+    job = db.get(Job, job_id)
+    if job is None:
+        return None
+    job.state = JobState.FAILED
+    job.error = error
+    if artifacts:
+        data = dict(job.artifacts or {})
+        data.update(artifacts)
+        job.artifacts = data
+    db.commit()
+    db.refresh(job)
+    return job

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,8 @@ def test_app() -> Generator[
     tuple[
         TestClient,
         ObjectStore,
-        List[Tuple[str, str | None]],
-        sessionmaker,
+        List[Tuple[str, str | None, str | None]],
+        sessionmaker[Session],
     ],
     None,
     None,
@@ -90,12 +90,14 @@ def test_app() -> Generator[
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_object_store] = lambda: store
 
-    calls: List[Tuple[str, str | None]] = []
+    calls: List[Tuple[str, str | None, str | None]] = []
 
     from worker import main as worker_main
 
-    def fake_delay(doc_id: str, request_id: str | None = None) -> None:
-        calls.append((doc_id, request_id))
+    def fake_delay(
+        doc_id: str, request_id: str | None = None, job_id: str | None = None
+    ) -> None:
+        calls.append((doc_id, request_id, job_id))
 
     worker_main.parse_document.delay = fake_delay
 

--- a/tests/test_ingest_crawl.py
+++ b/tests/test_ingest_crawl.py
@@ -15,9 +15,11 @@ def _setup_worker(store, SessionLocal):
 
 def test_ingest_crawl(test_app) -> None:
     client, store, calls, SessionLocal = test_app
-    crawl_calls: list[tuple[str, str, str | None, int, int, str | None]] = []
-    worker_main.crawl_document.delay = lambda doc_id, base_url, allow_prefix, max_depth, max_pages, request_id=None: crawl_calls.append(
-        (doc_id, base_url, allow_prefix, max_depth, max_pages, request_id)
+    crawl_calls: list[tuple[str, str, str | None, int, int, str | None, str | None]] = (
+        []
+    )
+    worker_main.crawl_document.delay = lambda doc_id, base_url, allow_prefix, max_depth, max_pages, request_id=None, job_id=None: crawl_calls.append(
+        (doc_id, base_url, allow_prefix, max_depth, max_pages, request_id, job_id)
     )
 
     resp = client.post(
@@ -55,7 +57,7 @@ def test_ingest_crawl(test_app) -> None:
     httpx.get = mock_get
 
     worker_main.parse_document.delay = (
-        lambda doc_id, request_id=None: worker_main.parse_document(doc_id)
+        lambda doc_id, request_id=None, job_id=None: worker_main.parse_document(doc_id)
     )
     worker_main.crawl_document(doc_id, "http://example.com/a", "/", 2, 5)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,35 @@
+from models import JobState, JobType
+from services.jobs import create_job, set_done, set_failed, set_progress
+from tests.conftest import PROJECT_ID_1
+
+
+def test_job_serialization(test_app) -> None:
+    client, _store, _calls, SessionLocal = test_app
+    with SessionLocal() as db:
+        job = create_job(db, JobType.PARSE, PROJECT_ID_1, None)
+        job_id = job.id
+    resp = client.get(f"/jobs/{job_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == str(job_id)
+    assert data["type"] == JobType.PARSE.value
+    assert data["state"] == JobState.QUEUED.value
+
+
+def test_job_lifecycle(test_app) -> None:
+    client, _store, _calls, SessionLocal = test_app
+    with SessionLocal() as db:
+        job = create_job(db, JobType.EXPORT, PROJECT_ID_1, None)
+        set_progress(db, job.id, 40, {"foo": "bar"})
+        set_done(db, job.id, {"baz": "qux"})
+        db.refresh(job)
+        assert job.state == JobState.SUCCEEDED
+        assert job.progress == 100
+        assert job.artifacts["foo"] == "bar"
+        assert job.artifacts["baz"] == "qux"
+        second = create_job(db, JobType.DATASET, PROJECT_ID_1, None)
+        set_failed(db, second.id, "boom")
+    resp = client.get("/jobs")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["total"] >= 2


### PR DESCRIPTION
## Summary
- add Job model and helpers for tracking background tasks
- expose job lookup/list APIs and Postman examples
- wire worker tasks to update job progress and results

## Testing
- `make lint`
- `make test`
- `PYTHONPATH=. alembic upgrade head` *(fails: could not translate host name "postgres" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb320fdf8832bb0a0aa757aa392c9