### PR TITLE
feat: add document reparse endpoint

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -192,6 +192,16 @@ class CrawlPayload(BaseModel):
     max_pages: int
 
 
+class ParserOverrides(BaseModel):
+    chunk_size: int | None = None
+    overlap: int | None = None
+    normalize: bool | None = None
+
+
+class ReparsePayload(BaseModel):
+    parser_overrides: ParserOverrides | None = None
+
+
 class ActiveLearningEntry(BaseModel):
     chunk_id: str
     reasons: List[str]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,17 @@ def test_app() -> Generator[
     tuple[
         TestClient,
         ObjectStore,
-        List[Tuple[str, str | None, str | None]],
+        List[
+            Tuple[
+                str,
+                int,
+                dict | None,
+                list | None,
+                bool,
+                str | None,
+                str | None,
+            ]
+        ],
         sessionmaker[Session],
     ],
     None,
@@ -90,14 +100,40 @@ def test_app() -> Generator[
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_object_store] = lambda: store
 
-    calls: List[Tuple[str, str | None, str | None]] = []
+    calls: List[
+        Tuple[
+            str,
+            int,
+            dict | None,
+            list | None,
+            bool,
+            str | None,
+            str | None,
+        ]
+    ] = []
 
     from worker import main as worker_main
 
     def fake_delay(
-        doc_id: str, request_id: str | None = None, job_id: str | None = None
+        doc_id: str,
+        version: int,
+        parser_overrides: dict | None = None,
+        stages: list | None = None,
+        reset_suggestions: bool = False,
+        job_id: str | None = None,
+        request_id: str | None = None,
     ) -> None:
-        calls.append((doc_id, request_id, job_id))
+        calls.append(
+            (
+                doc_id,
+                version,
+                parser_overrides,
+                stages,
+                reset_suggestions,
+                job_id,
+                request_id,
+            )
+        )
 
     worker_main.parse_document.delay = fake_delay
 

--- a/tests/test_iaa_conflicts.py
+++ b/tests/test_iaa_conflicts.py
@@ -32,7 +32,7 @@ def test_iaa_and_conflicts(test_app) -> None:
     worker_main.SessionLocal = SessionLocal  # type: ignore[assignment]
     worker_main._get_store = lambda: store  # type: ignore[assignment]
     try:
-        worker_main.parse_document(doc_id)
+        worker_main.parse_document(doc_id, 1)
     finally:
         worker_main.SessionLocal = orig_session  # type: ignore[assignment]
         worker_main._get_store = orig_store  # type: ignore[assignment]

--- a/tests/test_ingest_crawl.py
+++ b/tests/test_ingest_crawl.py
@@ -56,8 +56,8 @@ def test_ingest_crawl(test_app) -> None:
 
     httpx.get = mock_get
 
-    worker_main.parse_document.delay = (
-        lambda doc_id, request_id=None, job_id=None: worker_main.parse_document(doc_id)
+    worker_main.parse_document.delay = lambda doc_id, version, parser_overrides=None, stages=None, reset_suggestions=False, job_id=None, request_id=None: worker_main.parse_document(
+        doc_id, version
     )
     worker_main.crawl_document(doc_id, "http://example.com/a", "/", 2, 5)
 

--- a/tests/test_ingest_zip_bundle.py
+++ b/tests/test_ingest_zip_bundle.py
@@ -31,7 +31,7 @@ def test_ingest_zip_bundle(test_app) -> None:
     assert [c[0] for c in calls] == [doc_id]
 
     _setup_worker(store, SessionLocal)
-    worker_main.parse_document(doc_id)
+    worker_main.parse_document(doc_id, 1)
 
     chunks_key = derived_key(doc_id, "chunks.jsonl")
     manifest_key = derived_key(doc_id, "manifest.json")

--- a/tests/test_manifest_deltas.py
+++ b/tests/test_manifest_deltas.py
@@ -27,13 +27,13 @@ def test_manifest_deltas(test_app):
     )
     doc_id = resp.json()["doc_id"]
 
-    worker_main.parse_document(doc_id)
+    worker_main.parse_document(doc_id, 1)
 
     # mutate second paragraph
     html2 = b"<html><body><h1>A</h1><p>alpha</p><h1>B</h1><p>beta2</p></body></html>"
     store.put_bytes(raw_key(doc_id, "a.html"), html2)
 
-    worker_main.parse_document(doc_id)
+    worker_main.parse_document(doc_id, 1)
 
     manifest = json.loads(store.client.store[derived_key(doc_id, "manifest.json")])
     assert manifest["deltas"] == {"added": 0, "removed": 0, "changed": 1}

--- a/tests/test_parser_settings.py
+++ b/tests/test_parser_settings.py
@@ -38,7 +38,7 @@ def test_parser_settings_toggle(test_app) -> None:
     doc_id = resp.json()["doc_id"]
 
     _setup_worker(store, SessionLocal)
-    worker_main.parse_document(doc_id)
+    worker_main.parse_document(doc_id, 1)
 
     with SessionLocal() as db:
         ver = db.scalar(

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -40,7 +40,7 @@ def test_pii_detection_and_export_toggle(test_app) -> None:
         files={"file": ("x.html", html, "text/html")},
     )
     doc_id = resp.json()["doc_id"]
-    parse_document(doc_id)
+    parse_document(doc_id, 1)
     with SessionLocal() as db:
         chunk = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc_id))
         assert chunk is not None

--- a/tests/test_project_settings.py
+++ b/tests/test_project_settings.py
@@ -91,7 +91,7 @@ def test_worker_respects_settings_toggle(test_app) -> None:
         files={"file": ("a.html", html, "text/html")},
     )
     doc1 = resp1.json()["doc_id"]
-    worker_main.parse_document(doc1)
+    worker_main.parse_document(doc1, 1)
     with SessionLocal() as db:
         chunk1 = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc1))
         assert chunk1 is not None
@@ -112,7 +112,7 @@ def test_worker_respects_settings_toggle(test_app) -> None:
         files={"file": ("b.html", html2, "text/html")},
     )
     doc2 = resp2.json()["doc_id"]
-    worker_main.parse_document(doc2)
+    worker_main.parse_document(doc2, 1)
     with SessionLocal() as db:
         chunk2 = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc2))
         assert chunk2 is not None

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -17,7 +17,7 @@ def test_quality_gates_parse_metrics(test_app) -> None:
     worker_main.SessionLocal = SessionLocal  # type: ignore[assignment]
     worker_main._get_store = lambda: store  # type: ignore[assignment]
     try:
-        worker_main.parse_document(doc_id)
+        worker_main.parse_document(doc_id, 1)
     finally:
         worker_main.SessionLocal = orig_session  # type: ignore[assignment]
         worker_main._get_store = orig_store  # type: ignore[assignment]
@@ -57,7 +57,7 @@ def test_quality_gates_after_metadata_change(test_app) -> None:
     worker_main.SessionLocal = SessionLocal  # type: ignore[assignment]
     worker_main._get_store = lambda: store  # type: ignore[assignment]
     try:
-        worker_main.parse_document(doc_id)
+        worker_main.parse_document(doc_id, 1)
     finally:
         worker_main.SessionLocal = orig_session  # type: ignore[assignment]
         worker_main._get_store = orig_store  # type: ignore[assignment]

--- a/tests/test_quality_gates_v2.py
+++ b/tests/test_quality_gates_v2.py
@@ -19,7 +19,7 @@ def test_quality_gates_v2_metrics(test_app) -> None:
     worker_main.SessionLocal = SessionLocal  # type: ignore[assignment]
     worker_main._get_store = lambda: store  # type: ignore[assignment]
     try:
-        worker_main.parse_document(doc_id)
+        worker_main.parse_document(doc_id, 1)
     finally:
         worker_main.SessionLocal = orig_session  # type: ignore[assignment]
         worker_main._get_store = orig_store  # type: ignore[assignment]

--- a/tests/test_reparse.py
+++ b/tests/test_reparse.py
@@ -1,0 +1,41 @@
+from models import Document
+from tests.conftest import PROJECT_ID_1
+
+
+def test_reparse_in_place(test_app) -> None:
+    client, _, calls, SessionLocal = test_app
+    data = b"<html><body>hello</body></html>"
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("a.html", data, "text/html")},
+    )
+    doc_id = resp.json()["doc_id"]
+    calls.clear()
+    resp2 = client.post(f"/documents/{doc_id}/reparse")
+    assert resp2.status_code == 200
+    body = resp2.json()
+    assert body["version"] == 1
+    assert calls and calls[0][0] == doc_id and calls[0][1] == 1
+
+
+def test_reparse_version_bump(test_app) -> None:
+    client, _, calls, SessionLocal = test_app
+    data = b"<html><body>hello</body></html>"
+    resp = client.post(
+        "/ingest",
+        data={"project_id": str(PROJECT_ID_1)},
+        files={"file": ("a.html", data, "text/html")},
+    )
+    doc_id = resp.json()["doc_id"]
+    calls.clear()
+    resp2 = client.post(
+        f"/documents/{doc_id}/reparse", params={"force_version_bump": "true"}
+    )
+    assert resp2.status_code == 200
+    body = resp2.json()
+    assert body["version"] == 2
+    assert calls and calls[0][0] == doc_id and calls[0][1] == 2
+    with SessionLocal() as db:
+        doc = db.get(Document, doc_id)
+        assert doc is not None and doc.latest_version.version == 2

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -15,7 +15,7 @@ def test_request_id_propagates_to_celery(test_app) -> None:
     )
     assert resp.status_code == 200
     doc_id = resp.json()["doc_id"]
-    assert calls == [(doc_id, "rid-123")]
+    assert calls and calls[0][0] == doc_id and calls[0][-1] == "rid-123"
 
 
 def test_worker_logs_include_request_id(caplog) -> None:

--- a/tests/test_suggestors.py
+++ b/tests/test_suggestors.py
@@ -55,7 +55,7 @@ def test_pipeline_populates_suggestions(test_app) -> None:
         files={"file": ("x.html", html, "text/html")},
     )
     doc_id = resp.json()["doc_id"]
-    worker_main.parse_document(doc_id)
+    worker_main.parse_document(doc_id, 1)
     with SessionLocal() as db:
         chunk = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc_id))
         assert chunk is not None
@@ -84,7 +84,7 @@ def test_pipeline_respects_project_limit(test_app) -> None:
         files={"file": ("x.html", html, "text/html")},
     )
     doc_id = resp.json()["doc_id"]
-    worker_main.parse_document(doc_id)
+    worker_main.parse_document(doc_id, 1)
     with SessionLocal() as db:
         chunk = db.scalar(sa.select(ChunkModel).where(ChunkModel.document_id == doc_id))
         assert chunk is not None

--- a/tests/test_worker_error_rollback.py
+++ b/tests/test_worker_error_rollback.py
@@ -29,7 +29,7 @@ def test_parse_error_rolls_back(test_app, monkeypatch):
     monkeypatch.setattr(worker_main, "_run_parse", boom)
 
     with pytest.raises(RuntimeError) as excinfo:
-        worker_main.parse_document(doc_id)
+        worker_main.parse_document(doc_id, 1)
     assert "InFailedSqlTransaction" not in str(excinfo.value)
 
     with SessionLocal() as db:

--- a/tests/test_worker_parse.py
+++ b/tests/test_worker_parse.py
@@ -28,7 +28,7 @@ def test_parse_pdf_and_write_chunks(test_app):
     )
     doc_id = resp.json()["doc_id"]
 
-    worker_main.parse_document(doc_id)
+    worker_main.parse_document(doc_id, 1)
 
     resp_chunks = client.get(f"/documents/{doc_id}/chunks")
     assert resp_chunks.json()["total"] > 0
@@ -55,7 +55,7 @@ def test_parse_failure_sets_status(test_app):
         dv.mime = "application/x-unknown"
         db.commit()
 
-    worker_main.parse_document(doc_id)
+    worker_main.parse_document(doc_id, 1)
 
     resp_doc = client.get(f"/documents/{doc_id}")
     body = resp_doc.json()


### PR DESCRIPTION
## Summary
- add POST /documents/{doc_id}/reparse for in-place or version-bumped parsing
- extend worker parse_document to accept version and parser overrides
- adjust chunker to allow optional normalization overrides

## Testing
- `make lint`
- `make test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer'; missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb8ff8444832ba77e575b8a9c2a40