### PR TITLE
feat: add project soft delete

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -123,6 +123,7 @@
 | F40-14 | Notifications | codex | ☑ Done | [PR](#) |  |
 | F40-15 | Guideline assistant | codex | ☐ In Progress | [PR](#) |  |
 | N/A | JSONB native types | codex | ☑ Done | [PR](#) |  |
+| N/A | Project soft delete | codex | ☑ Done | [PR](#) |  |
 
 ---
 

--- a/alembic/versions/0011_add_project_soft_delete.py
+++ b/alembic/versions/0011_add_project_soft_delete.py
@@ -1,0 +1,31 @@
+"""add soft delete to projects"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0011_add_project_soft_delete"
+down_revision = "0010_add_jobs_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "projects",
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "projects",
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "is_active")
+    op.drop_column("projects", "deleted_at")

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -99,6 +99,7 @@ class ProjectSummary(BaseModel):
     slug: str
     created_at: datetime
     updated_at: datetime
+    is_active: bool
 
 
 class ProjectsListResponse(BaseModel):

--- a/models/chunk.py
+++ b/models/chunk.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql import func
 
 from .base import Base
 
-json_dict = MutableDict.as_mutable(JSONB)
+json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
 
 
 class Chunk(Base):

--- a/models/document.py
+++ b/models/document.py
@@ -18,7 +18,7 @@ class DocumentStatus(str, enum.Enum):
     FAILED = "failed"
 
 
-json_dict = MutableDict.as_mutable(JSONB)
+json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
 
 
 class Document(Base):

--- a/models/job.py
+++ b/models/job.py
@@ -26,7 +26,7 @@ class JobState(str, enum.Enum):
     FAILED = "failed"
 
 
-json_dict = MutableDict.as_mutable(JSONB)
+json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
 
 
 class Job(Base):

--- a/models/project.py
+++ b/models/project.py
@@ -8,8 +8,8 @@ from sqlalchemy.sql import func
 
 from .base import Base
 
-json_dict = MutableDict.as_mutable(JSONB)
-json_list = MutableList.as_mutable(JSONB)
+json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
+json_list = MutableList.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
 
 
 class Project(Base):
@@ -55,6 +55,12 @@ class Project(Base):
         nullable=False,
         default=lambda: {"max_depth": 2, "max_pages": 50},
         server_default=sa.text('\'{"max_depth":2,"max_pages":50}\''),
+    )
+    deleted_at: Mapped[sa.types.DateTime | None] = mapped_column(
+        sa.DateTime(timezone=True), nullable=True
+    )
+    is_active: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, default=True, server_default=sa.text("true")
     )
     created_at: Mapped[sa.types.DateTime] = mapped_column(
         sa.DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/tests/test_project_soft_delete.py
+++ b/tests/test_project_soft_delete.py
@@ -1,0 +1,45 @@
+def test_delete_restore_and_listing_behavior(test_app) -> None:
+    client, _, _, _ = test_app
+    resp = client.post("/projects", json={"name": "Soft", "slug": "soft"})
+    pid = resp.json()["id"]
+    resp_ing = client.post(
+        "/ingest",
+        data={"project_id": pid},
+        files={"file": ("a.pdf", b"alpha", "application/pdf")},
+    )
+    assert resp_ing.status_code == 200
+    del_resp = client.delete(
+        f"/projects/{pid}?soft=true", headers={"X-Role": "curator"}
+    )
+    assert del_resp.status_code == 200
+    fail_ing = client.post(
+        "/ingest",
+        data={"project_id": pid},
+        files={"file": ("b.pdf", b"beta", "application/pdf")},
+    )
+    assert fail_ing.status_code == 400
+    resp_list = client.get("/projects", headers={"X-Role": "viewer"})
+    ids = {p["id"] for p in resp_list.json()["projects"]}
+    assert pid not in ids
+    resp_all = client.get(
+        "/projects?include_deleted=true", headers={"X-Role": "viewer"}
+    )
+    all_projects = resp_all.json()["projects"]
+    assert any(p["id"] == pid and p["is_active"] is False for p in all_projects)
+    resp_docs = client.get("/documents", params={"project_id": pid})
+    assert resp_docs.json()["total"] == 0
+    resp_docs_all = client.get(
+        "/documents", params={"project_id": pid, "include_deleted": True}
+    )
+    assert resp_docs_all.json()["total"] == 1
+    res_restore = client.post(f"/projects/{pid}/restore", headers={"X-Role": "curator"})
+    assert res_restore.status_code == 200
+    resp_ing2 = client.post(
+        "/ingest",
+        data={"project_id": pid},
+        files={"file": ("c.pdf", b"gamma", "application/pdf")},
+    )
+    assert resp_ing2.status_code == 200
+    resp_list2 = client.get("/projects", headers={"X-Role": "viewer"})
+    ids2 = {p["id"] for p in resp_list2.json()["projects"]}
+    assert pid in ids2

--- a/tests/test_projects_list.py
+++ b/tests/test_projects_list.py
@@ -34,6 +34,7 @@ def test_list_projects_returns_project(test_app) -> None:
     assert proj["slug"] == "alpha"
     assert proj["created_at"]
     assert proj["updated_at"]
+    assert proj["is_active"] is True
 
 
 def test_list_projects_pagination(test_app) -> None:


### PR DESCRIPTION
## Summary
- support soft deletion of projects and restore action
- hide inactive projects/docs from lists unless explicitly included
- cover delete/restore flows with tests

## Testing
- `make lint`
- `python -m mypy models/project.py api/main.py api/schemas.py tests/test_project_soft_delete.py tests/test_projects_list.py`
- `pytest tests/test_project_soft_delete.py tests/test_projects_list.py tests/test_documents.py`
- `alembic upgrade head` *(fails: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68aec0b3bc7c832b94f70b06fa054a3b