### PR TITLE
feat: add dataset management

### DIFF
--- a/alembic/versions/0012_add_datasets_table.py
+++ b/alembic/versions/0012_add_datasets_table.py
@@ -1,0 +1,54 @@
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "datasets",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Uuid(as_uuid=True),
+            sa.ForeignKey("projects.id"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column(
+            "filters",
+            sa.JSON().with_variant(postgresql.JSONB, "postgresql"),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column("snapshot_uri", sa.Text(), nullable=True),
+        sa.Column(
+            "stats",
+            sa.JSON().with_variant(postgresql.JSONB, "postgresql"),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_datasets_project_id", "datasets", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_datasets_project_id", table_name="datasets")
+    op.drop_table("datasets")

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -231,3 +231,36 @@ class JobResponse(BaseModel):
 class JobsListResponse(BaseModel):
     jobs: List[JobResponse]
     total: int
+
+
+class DatasetCreate(BaseModel):
+    name: str
+    project_id: str
+    filters: Dict[str, Any]
+
+
+class DatasetResponse(BaseModel):
+    id: UUID
+    project_id: UUID
+    name: str
+    filters: Dict[str, Any]
+    snapshot_uri: str | None = None
+    stats: Dict[str, Any] | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SignedUrlResponse(BaseModel):
+    url: str
+
+
+class ValidationPayload(BaseModel):
+    dataset_id: str | None = None
+    url: str | None = None
+
+
+class ValidationResponse(BaseModel):
+    status: str
+    metrics: Dict[str, int]
+    issues: List[str]
+    report_url: str

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,7 @@
 from .audit import Audit
 from .base import Base
 from .chunk import Chunk
+from .dataset import Dataset
 from .document import Document, DocumentStatus, DocumentVersion
 from .job import Job, JobState, JobType
 from .project import Project
@@ -20,4 +21,5 @@ __all__ = [
     "Taxonomy",
     "Audit",
     "Release",
+    "Dataset",
 ]

--- a/models/dataset.py
+++ b/models/dataset.py
@@ -1,0 +1,37 @@
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from .base import Base
+
+json_dict = MutableDict.as_mutable(sa.JSON().with_variant(JSONB, "postgresql"))
+
+
+class Dataset(Base):
+    __tablename__ = "datasets"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), sa.ForeignKey("projects.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    filters: Mapped[dict] = mapped_column(json_dict, default=dict, nullable=False)
+    snapshot_uri: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    stats: Mapped[dict] = mapped_column(json_dict, default=dict, nullable=False)
+    created_at: Mapped[sa.types.DateTime] = mapped_column(
+        sa.DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[sa.types.DateTime] = mapped_column(
+        sa.DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (sa.Index("ix_datasets_project_id", "project_id"),)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,130 @@
+from typing import Dict
+
+from models import Chunk, Document, DocumentStatus, DocumentVersion
+from tests.conftest import PROJECT_ID_1
+
+
+def _add_doc(SessionLocal, doc_id: str, metadata: Dict) -> None:
+    with SessionLocal() as session:
+        doc = Document(id=doc_id, project_id=PROJECT_ID_1, source_type="text")
+        session.add(doc)
+        session.flush()
+        version = DocumentVersion(
+            document_id=doc_id,
+            project_id=PROJECT_ID_1,
+            version=1,
+            doc_hash=f"h-{doc_id}",
+            mime="text/plain",
+            size=1,
+            status=DocumentStatus.PARSED.value,
+        )
+        session.add(version)
+        session.flush()
+        doc.latest_version_id = version.id
+        chunk = Chunk(
+            id=f"{doc_id}-c1",
+            document_id=doc_id,
+            version=1,
+            order=0,
+            content={"type": "text", "text": "hello"},
+            text_hash="t",
+            meta=metadata,
+        )
+        session.add(chunk)
+        session.commit()
+
+
+def test_create_dataset(test_app) -> None:
+    client, _, _, _ = test_app
+    resp = client.post(
+        "/datasets",
+        json={"name": "ds1", "project_id": str(PROJECT_ID_1), "filters": {}},
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "ds1"
+    assert data["project_id"] == str(PROJECT_ID_1)
+
+
+def test_materialize_dataset_counts(test_app) -> None:
+    client, store, _, SessionLocal = test_app
+    _add_doc(SessionLocal, "d1", {})
+    resp = client.post(
+        "/datasets",
+        json={
+            "name": "ds2",
+            "project_id": str(PROJECT_ID_1),
+            "filters": {"doc_ids": ["d1"]},
+        },
+        headers={"X-Role": "curator"},
+    )
+    dataset_id = resp.json()["id"]
+    resp = client.post(
+        f"/datasets/{dataset_id}/materialize",
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["stats"]["rows"] > 0
+    assert data["stats"]["docs"] == 1
+    assert (
+        store.client.store.get(f"derived/datasets/{dataset_id}/snapshot.jsonl")
+        is not None
+    )
+
+
+def test_validate_dataset_fail_empty_label(test_app) -> None:
+    client, _, _, SessionLocal = test_app
+    _add_doc(SessionLocal, "d2", {"label": ""})
+    resp = client.post(
+        "/datasets",
+        json={
+            "name": "ds3",
+            "project_id": str(PROJECT_ID_1),
+            "filters": {"doc_ids": ["d2"]},
+        },
+        headers={"X-Role": "curator"},
+    )
+    dataset_id = resp.json()["id"]
+    client.post(
+        f"/datasets/{dataset_id}/materialize",
+        headers={"X-Role": "curator"},
+    )
+    resp = client.post(
+        "/exports/validate",
+        json={"dataset_id": dataset_id},
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "failed"
+    assert any("empty label" in issue for issue in data["issues"])
+
+
+def test_validate_dataset_pass(test_app) -> None:
+    client, _, _, SessionLocal = test_app
+    _add_doc(SessionLocal, "d3", {"label": "ok"})
+    resp = client.post(
+        "/datasets",
+        json={
+            "name": "ds4",
+            "project_id": str(PROJECT_ID_1),
+            "filters": {"doc_ids": ["d3"]},
+        },
+        headers={"X-Role": "curator"},
+    )
+    dataset_id = resp.json()["id"]
+    client.post(
+        f"/datasets/{dataset_id}/materialize",
+        headers={"X-Role": "curator"},
+    )
+    resp = client.post(
+        "/exports/validate",
+        json={"dataset_id": dataset_id},
+        headers={"X-Role": "curator"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "passed"
+    assert data["issues"] == []


### PR DESCRIPTION
## Summary
- add Dataset model and migration
- expose dataset create, materialize, export, and validate endpoints
- store dataset snapshots and validation reports in object storage

## Testing
- `make lint` *(fails: worker/main.py type errors)*
- `make test`
- `pytest tests/test_datasets.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedbcb63fc832b822bbc1b90c6c44a