### PR TITLE
feat: add document manifest and chunk stream endpoints

### DIFF
--- a/docs/postman/InstructifyAI_Labeler_Phase1.postman_collection.json
+++ b/docs/postman/InstructifyAI_Labeler_Phase1.postman_collection.json
@@ -290,6 +290,24 @@
           }
         },
         {
+          "name": "Get Document Manifest",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/documents/{{doc_id}}/manifest",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "documents",
+                "{{doc_id}}",
+                "manifest"
+              ]
+            }
+          }
+        },
+        {
           "name": "Re-parse Document",
           "request": {
             "method": "POST",
@@ -308,7 +326,7 @@
           }
         },
         {
-          "name": "List Chunks",
+          "name": "Stream Chunks (NDJSON)",
           "request": {
             "method": "GET",
             "header": [],


### PR DESCRIPTION
## Summary
- add endpoint to fetch document manifest from object store
- stream chunks.jsonl via `/documents/{doc_id}/chunks` with optional offset & limit
- adjust tests and Postman collection for new helpers

## Testing
- `make lint` *(fails: worker/main.py mypy errors)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aedf813c74832bae1fd75cb3b9ee04